### PR TITLE
fix: invalid docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+version: "3"
+
 services:
   chirpstack:
     image: chirpstack/chirpstack-dev-cache:latest


### PR DESCRIPTION
Unsupported config option due to invalid docker-compose.yml file due to not specifying compose version in compose file.

![fix docker-compose](https://user-images.githubusercontent.com/43664335/165082541-533fd56e-d2e7-4044-9363-33efc0418b27.jpg)
