### PR TITLE
Use trust_store instead of ca_path

### DIFF
--- a/chirpstack/src/gateway/backend/mqtt.rs
+++ b/chirpstack/src/gateway/backend/mqtt.rs
@@ -157,7 +157,7 @@ impl<'a> MqttBackend<'a> {
 
             if !conf.ca_cert.is_empty() {
                 ssl_opts_b
-                    .ca_path(&conf.ca_cert)
+                    .trust_store(&conf.ca_cert)
                     .context("Failed to set gateway ca_cert")?;
             }
 


### PR DESCRIPTION
Hi,

First I would like to thank you for your incredible work !

I'm currently testing chirpstack v4 and tried to connect to a HiveMQ hosted mqtt server without any success while the previous version of chirpstack was working properly.

After doing some research and tried out few thing, I understood that the problem comes from the paho mqtt library for rust. It requires a certificate (even if the server does not), but even with giving the root ca it still not working. However I've been able to make it work by changing the function ca_cert into trust_store and give the path of the root ca.

I've been able to test using the make test-server target and connect to my broker.

So if you think this function should be changed then please merge, otherwise is it possible to have an option to give the root ca and add it in the trust store?

Thanks again