### PR TITLE
Use trust_store instead of ca_path for mqtt integration

### DIFF
--- a/chirpstack/src/integration/mqtt.rs
+++ b/chirpstack/src/integration/mqtt.rs
@@ -113,7 +113,7 @@ impl<'a> Integration<'a> {
 
             if !conf.ca_cert.is_empty() {
                 ssl_opts_b
-                    .ca_path(&conf.ca_cert)
+                    .trust_store(&conf.ca_cert)
                     .context("Failed to set gateway ca_cert")?;
             }
 


### PR DESCRIPTION
In https://github.com/chirpstack/chirpstack/pull/37, a function call to `ca_path` was changed to `trust_store`, in order to fix an SSL error when establishing an MQTT connection in `chirpstack/src/gateway/backend/mqtt.rs`. However, there's another location where Chirpstack attempts to establish an MQTT connection in `chirpstack/src/integration/mqtt.rs`. This PR updates that file with the same fix.