### PR TITLE
Implement Azure IoT Hub GW <> NS backend 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,6 +907,7 @@ dependencies = [
  "clap 4.0.8",
  "diesel",
  "diesel_migrations",
+ "fe2o3-amqp",
  "futures",
  "gcp_auth",
  "geohash",
@@ -923,6 +924,7 @@ dependencies = [
  "lazy_static",
  "lrwn",
  "mime_guess",
+ "mio 0.7.14",
  "openidconnect",
  "openssl",
  "paho-mqtt",
@@ -943,7 +945,9 @@ dependencies = [
  "reqwest",
  "rquickjs",
  "rust-embed",
+ "rustls 0.19.1",
  "serde",
+ "serde_amqp",
  "serde_json",
  "serde_yaml",
  "sha2",
@@ -951,7 +955,9 @@ dependencies = [
  "tokio",
  "tokio-executor-trait",
  "tokio-reactor-trait",
+ "tokio-rustls 0.23.4",
  "tokio-stream",
+ "tokio-util 0.7.4",
  "toml",
  "tonic",
  "tonic-reflection",
@@ -964,6 +970,7 @@ dependencies = [
  "uuid",
  "validator",
  "warp",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1121,6 +1128,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4a24b1aaf0fd0ce8b45161144d6f42cd91677fd5940fd431183eb023b3a2b8"
+
+[[package]]
 name = "cookie-factory"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,6 +1254,41 @@ dependencies = [
  "pkg-config",
  "vcpkg",
  "winapi",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1365,6 +1413,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6053ff46b5639ceb91756a85a4c8914668393a03170efd79c8884a529d80656"
 
 [[package]]
+name = "duct"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc6a0a59ed0888e0041cf708e66357b7ae1a82f1c67247e1f93b5e0818f7d8d"
+dependencies = [
+ "libc",
+ "once_cell",
+ "os_pipe",
+ "shared_child",
+]
+
+[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1423,6 +1483,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "fe2o3-amqp"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aa938c6ea730b3324b008f40ee720f34f521d470e664e52faf91b6052afef40"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "fe2o3-amqp-types",
+ "futures-util",
+ "parking_lot",
+ "pin-project-lite",
+ "rustls 0.20.6",
+ "serde",
+ "serde_amqp",
+ "serde_bytes",
+ "slab",
+ "thiserror",
+ "tokio",
+ "tokio-rustls 0.23.4",
+ "tokio-stream",
+ "tokio-util 0.7.4",
+ "tracing",
+ "url",
+ "webpki-roots",
+]
+
+[[package]]
+name = "fe2o3-amqp-types"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0649bf9dbf60541e51a01cdcc3bd18c4e938faa957fee99c2559ebd123334f88"
+dependencies = [
+ "ordered-float 3.2.0",
+ "serde",
+ "serde_amqp",
+ "serde_bytes",
+ "serde_repr",
 ]
 
 [[package]]
@@ -1940,6 +2040,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1968,6 +2074,7 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -2058,6 +2165,15 @@ dependencies = [
  "serde",
  "serde_json",
  "simple_asn1",
+]
+
+[[package]]
+name = "krb5-src"
+version = "0.3.2+1.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44cd3b7e7735d48bc3793837041294f2eb747bd0f63bbc081e89972abb9e48fb"
+dependencies = [
+ "duct",
 ]
 
 [[package]]
@@ -2282,6 +2398,19 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
+name = "mio"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
@@ -2290,6 +2419,15 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -2348,6 +2486,15 @@ checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -2538,6 +2685,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "129d36517b53c461acc6e1580aeb919c8ae6708a4b1eae61c4463a615d4f0411"
+dependencies = [
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "os_pipe"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb233f06c2307e1f5ce2ecad9f8121cffbbee2c95428f44ea85222e460d0d213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -3076,7 +3243,9 @@ dependencies = [
  "libc",
  "libz-sys",
  "num_enum",
+ "openssl-sys",
  "pkg-config",
+ "sasl2-sys",
 ]
 
 [[package]]
@@ -3394,6 +3563,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sasl2-sys"
+version = "0.1.20+2.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e645bd98535fc8fd251c43ba7c7c1f9be1e0369c99b6a5ea719052a773e655c"
+dependencies = [
+ "cc",
+ "duct",
+ "krb5-src",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3488,7 +3670,44 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
- "ordered-float",
+ "ordered-float 2.10.0",
+ "serde",
+]
+
+[[package]]
+name = "serde_amqp"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cf46ac0330c95180848e1c17cb2e3430334d713bf4e673814d563a9754298b4"
+dependencies = [
+ "bytes",
+ "indexmap",
+ "ordered-float 3.2.0",
+ "serde",
+ "serde_amqp_derive",
+ "serde_bytes",
+ "thiserror",
+]
+
+[[package]]
+name = "serde_amqp_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a342626f001d05ea6ca3d2f15ca75085ed1923fe62aee5d722ca146d9470d7a"
+dependencies = [
+ "convert_case",
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
+dependencies = [
  "serde",
 ]
 
@@ -3531,6 +3750,17 @@ checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
 dependencies = [
  "regex",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3615,6 +3845,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shared_child"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6be9f7d5565b1483af3e72975e2dee33879b3b86bd48c0929fccf6585d79e65a"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -3904,7 +4144,7 @@ dependencies = [
  "bytes",
  "libc",
  "memchr",
- "mio",
+ "mio 0.8.4",
  "num_cpus",
  "once_cell",
  "pin-project-lite",

--- a/chirpstack/Cargo.toml
+++ b/chirpstack/Cargo.toml
@@ -18,6 +18,7 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 serde_yaml = "0.9"
 serde_json = "1.0"
 humantime-serde = "1.1"
+serde_amqp = "0.4.3"
 toml = "0.5"
 handlebars = "4.3"
 
@@ -50,11 +51,11 @@ hmac = "0.12"
 sha2 = "0.10"
 urlencoding = "2.1"
 geohash = "0.12"
-gcp_auth = "0.7"
-lapin = "2.1"
-tokio-executor-trait = "2.1"
-tokio-reactor-trait = "1.1"
-rdkafka = { version = "0.28", features = ["cmake-build"]}
+gcp_auth = "0.7.2"
+lapin = "2.1.1"
+tokio-executor-trait = "2.1.0"
+tokio-reactor-trait = "1.1.0"
+rdkafka = { version = "0.28.0", features = ["cmake-build","gssapi-vendored", "ssl-vendored"]}
 
 # gRPC and Protobuf
 tonic = "0.8"
@@ -109,10 +110,18 @@ petgraph = "0.6"
 prometheus-client = "0.18"
 pin-project = "1.0"
 
+rustls = "0.19.1"
+mio = { version = "0.7.11", features = ["tcp","os-poll"] }
+tokio-rustls = "0.23"
+webpki-roots = "0.22.4"
+fe2o3-amqp = {version = "0.6.3", features = ["rustls"]}
+tokio-util = "0.7.4"
+
 # Development and testing
 [dev-dependencies]
 httpmock = "0.6"
 bytes = "1.2"
+
 
 # Debian packaging.
 [package.metadata.deb]

--- a/chirpstack/src/config.rs
+++ b/chirpstack/src/config.rs
@@ -1,13 +1,13 @@
+use std::{env, fs};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use std::{env, fs};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
+use lrwn::{AES128Key, EUI64, NetID};
 use lrwn::region::CommonName;
-use lrwn::{AES128Key, NetID, EUI64};
 
 lazy_static! {
     static ref CONFIG: Mutex<Arc<Configuration>> = Mutex::new(Arc::new(Default::default()));
@@ -539,6 +539,11 @@ impl Default for Region {
                         clean_session: false,
                         ..Default::default()
                     },
+                    azure: GatewayBackendAzure {
+                        events_connection_string: "".into(),
+                        commands_connection_string: "".into(),
+                        ..Default::default()
+                    },
                 },
             },
         }
@@ -608,6 +613,7 @@ pub struct RegionGateway {
 pub struct GatewayBackend {
     pub enabled: String,
     pub mqtt: GatewayBackendMqtt,
+    pub azure: GatewayBackendAzure,
 }
 
 #[derive(Default, Serialize, Deserialize, Clone)]
@@ -624,6 +630,13 @@ pub struct GatewayBackendMqtt {
     pub ca_cert: String,
     pub tls_cert: String,
     pub tls_key: String,
+}
+
+#[derive(Default, Serialize, Deserialize, Clone)]
+#[serde(default)]
+pub struct GatewayBackendAzure {
+    pub events_connection_string: String,
+    pub commands_connection_string: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Hash)]

--- a/chirpstack/src/config.rs
+++ b/chirpstack/src/config.rs
@@ -1,13 +1,13 @@
-use std::{env, fs};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+use std::{env, fs};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
-use lrwn::{AES128Key, EUI64, NetID};
 use lrwn::region::CommonName;
+use lrwn::{AES128Key, NetID, EUI64};
 
 lazy_static! {
     static ref CONFIG: Mutex<Arc<Configuration>> = Mutex::new(Arc::new(Default::default()));

--- a/chirpstack/src/gateway/backend/azure.rs
+++ b/chirpstack/src/gateway/backend/azure.rs
@@ -917,9 +917,8 @@ pub mod test {
 
     #[test]
     fn test_check_payload_and_callback_ok() {
-        let callback = AzureBackend::check_payload_and_callback(r#"[{"id":"47b0b740-8c32-1d88-b84b-343c765f11d8","topic":"/SUBSCRIPTIONS/D2037D29-C0F0-4E03-8E1E-87A0BFEAF16F/RESOURCEGROUPS/TEST/PROVIDERS/MICROSOFT.DEVICES/IOTHUBS/HIBER-TEST-HUB","subject":"devices/test-cecile","eventType":"Microsoft.Devices.DeviceTelemetry","data":{"properties":{"event_type":"up","region":"eu868"},"systemProperties":{"iothub-connection-device-id":"test-cecile","iothub-connection-auth-method":"{\"scope\":\"device\",\"type\":\"sas\",\"issuer\":\"iothub\",\"acceptingIpFilterRule\":null}","iothub-connection-auth-generation-id":"637968607726449711","iothub-enqueuedtime":"2022-09-13T13:41:36.7740000Z","iothub-message-source":"Telemetry"},"body":"aGVsbG8="},"dataVersion":"","metadataVersion":"1","eventTime":"2022-09-13T13:41:36.774Z"}]
+        let callback = AzureBackend::check_payload_and_callback(r#"[{"id":"47b0b740-8c32-1d88-b84b-343c765f11d8","topic":"/SUBSCRIPTIONS/D2037D29-C0F0-4E03-8E1E-87A0BFEAF16F/RESOURCEGROUPS/TEST/PROVIDERS/MICROSOFT.DEVICES/IOTHUBS/HIBER-TEST-HUB","subject":"devices/test-cecile","eventType":"Microsoft.Devices.DeviceTelemetry","data":{"properties":{"up":""},"systemProperties":{"iothub-connection-device-id":"test-cecile","iothub-connection-auth-method":"{\"scope\":\"device\",\"type\":\"sas\",\"issuer\":\"iothub\",\"acceptingIpFilterRule\":null}","iothub-connection-auth-generation-id":"637968607726449711","iothub-enqueuedtime":"2022-09-13T13:41:36.7740000Z","iothub-message-source":"Telemetry"},"body":"aGVsbG8="},"dataVersion":"","metadataVersion":"1","eventTime":"2022-09-13T13:41:36.774Z"}]
 "#).unwrap();
-        assert_eq!(callback.region_name, "eu868");
         assert_eq!(callback.topic, "up");
         assert_eq!(callback.payload, decode(b"aGVsbG8=").unwrap());
     }

--- a/chirpstack/src/gateway/backend/azure.rs
+++ b/chirpstack/src/gateway/backend/azure.rs
@@ -1,0 +1,847 @@
+use std::{str, thread};
+#[cfg(test)]
+use std::{println as trace, println as info, println as error};
+use std::sync::mpsc;
+use std::sync::mpsc::{Receiver as ChanRceiver, SyncSender as ChanSender};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use anyhow::{Error, Result};
+use async_trait::async_trait;
+use base64::decode;
+use fe2o3_amqp::{
+    Connection, sasl_profile::SaslProfile, Sender, Session,
+};
+use fe2o3_amqp::{
+    types::{
+        messaging::{Message as AmqpMessage, Properties},
+        primitives::Binary,
+    },
+};
+use fe2o3_amqp::connection::ConnectionHandle;
+use fe2o3_amqp::session::SessionHandle;
+use fe2o3_amqp::types::messaging::ApplicationProperties;
+use hmac::{Hmac, Mac};
+use prost::Message;
+use rdkafka::config::ClientConfig;
+use rdkafka::consumer::{CommitMode, Consumer, StreamConsumer};
+use rdkafka::message::{BorrowedMessage, Message as KafkaMessage};
+use rdkafka::message::ToBytes;
+use serde_amqp;
+use serde_json::Value;
+use sha2::Sha256;
+use tokio_util::sync::CancellationToken;
+#[cfg(not(test))]
+use tracing::{error, info, trace};
+use uuid::Uuid;
+
+use lrwn::region::CommonName;
+
+use crate::config::GatewayBackendAzure;
+
+use super::common::COMMAND_COUNTER;
+use super::common::CommandLabels;
+use super::common::gateway_is_json;
+use super::common::message_callback;
+use super::GatewayBackend;
+
+struct BusConnectionInformation {
+    hostname: String,
+    shared_access_key_name: String,
+    shared_access_key: String,
+}
+
+struct EventConnectionInformation {
+    hub_name: String,
+    connection_string: String,
+    topic_name: String,
+}
+
+struct AzureKafkaClient {
+    consumer: Option<StreamConsumer>,
+}
+
+struct MessageProperties {
+    payload: Vec<u8>,
+    topic: String,
+}
+
+pub struct AzureBackend {
+    tx: Option<ChanSender<AmqpMessage<serde_amqp::value::Value>>>,
+}
+
+struct AmqpConnectivity {
+    connection: Option<ConnectionHandle<()>>,
+    session: Option<SessionHandle<()>>,
+}
+
+#[async_trait]
+trait SendConnectivity<T>: Send {
+    async fn connect(&mut self, parameters: &BusConnectionInformation, duration: Duration) -> Result<()>;
+    async fn reconnect(&mut self, parameters: &BusConnectionInformation, duration: Duration) -> Result<()>;
+    async fn send(&mut self, message: T) -> Result<()>;
+}
+
+impl AmqpConnectivity {
+    fn new() -> AmqpConnectivity {
+        return AmqpConnectivity {
+            session: None,
+            connection: None,
+        };
+    }
+}
+
+#[async_trait]
+impl SendConnectivity<AmqpMessage<serde_amqp::value::Value>> for AmqpConnectivity {
+    async fn connect(&mut self, parameters: &BusConnectionInformation, duration: Duration) -> Result<()> {
+        let port = 5671;
+        let sa_key_value = create_sas_token(&parameters.hostname, &parameters.shared_access_key_name, &parameters.shared_access_key, &(SystemTime::now() + duration)).unwrap();
+        let url = format!("amqps://{}:{}", &parameters.hostname, port);
+        let mut connection = match Connection::builder()
+            .container_id("rust-receiver-connection-1")
+            .alt_tls_establishment(true) // ServiceBus uses alternative TLS establishement
+            .hostname(&parameters.hostname[..])
+            .sasl_profile(SaslProfile::Plain {
+                username: parameters.shared_access_key_name.as_str().to_string(),
+                password: sa_key_value,
+            })
+            .open(&url[..])
+            .await {
+            Ok(c) => c,
+            Err(e) => {
+                error!("can not build connection{:?}",e);
+                return Err(Error::new(e));
+            }
+        };
+
+        let session = match Session::begin(&mut connection).await {
+            Ok(s) => s,
+            Err(e) => {
+                error!("can not build session{:?}",e);
+                return Err(Error::from(e));
+            }
+        };
+
+        self.connection = Some(connection);
+        self.session = Some(session);
+
+        Ok(())
+    }
+
+    async fn reconnect(&mut self, parameters: &BusConnectionInformation, duration: Duration) -> Result<()> {
+        match self.session.as_mut().unwrap().close().await {
+            Ok(r) => r,
+            Err(err) => {
+                trace!("can't close amqp connection: {:?}", err);
+                ()
+            }
+        };
+        match self.connection.as_mut().unwrap().close().await {
+            Ok(r) => r,
+            Err(err) => {
+                trace!("can't close amqp connection: {:?}", err);
+                ()
+            }
+        };
+        match self.connect(parameters, duration).await {
+            Ok(_) => (),
+            Err(err) => {
+                error!("can't connect: {:?}", err);
+                return Err(err);
+            }
+        };
+        Ok(())
+    }
+
+    async fn send(&mut self, message: AmqpMessage<serde_amqp::value::Value>) -> Result<()> {
+        let mut sender = match Sender::attach(&mut self.session.as_mut().unwrap(), "chirpstack-sender", "/messages/devicebound")
+            .await {
+            Ok(s) => s,
+            Err(e) => {
+                error!("can not create sender {:?}",e);
+                return Err(Error::new(e));
+            }
+        };
+
+        let outcome = match sender.send(message).await {
+            Ok(m) => m,
+            Err(e) => {
+                error!("error while sending amqp message {:?}",e);
+                return Err(Error::new(e));
+            }
+        };
+
+        let _ = match outcome.accepted_or_else(|outcome| outcome) {
+            Ok(_) => (),
+            Err(e) => {
+                error!("amqp message not accepted {:?}",e);
+                ()
+            }
+        };
+
+        match sender.close().await {
+            Ok(r) => r,
+            Err(e) => {
+                error!("can't close amqp sender: {:?}", e);
+                ()
+            }
+        };
+
+        Ok(())
+    }
+}
+
+impl AzureBackend {
+    pub async fn new(region_name: &str,
+                     region_common_name: CommonName, conf: &GatewayBackendAzure) -> Result<AzureBackend> {
+        let bus_information = build_bus_connection_string(conf.commands_connection_string.to_string()).unwrap();
+        let (tx, rx): (ChanSender<AmqpMessage<serde_amqp::value::Value>>, ChanRceiver<AmqpMessage<serde_amqp::value::Value>>) = mpsc::sync_channel(1000);
+        let azure_backend = AzureBackend {
+            tx: Some(tx),
+        };
+        let connectivity = AmqpConnectivity::new();
+        let token = CancellationToken::new();
+        tokio::spawn(async move {
+            AzureBackend::run_downlink(Box::new(connectivity), bus_information, rx, token).await;
+        });
+
+
+        let event_information = build_event_connection_string(conf.events_connection_string.to_string()).unwrap();
+        let region = region_name.to_string();
+        tokio::spawn(async move {
+            AzureBackend::run_uplink(region, region_common_name, event_information).await;
+        });
+
+        Ok(azure_backend)
+    }
+
+    async fn run_downlink(mut connectivity: Box<dyn SendConnectivity<AmqpMessage<serde_amqp::value::Value>>>, parameters: BusConnectionInformation, rx: ChanRceiver<AmqpMessage<serde_amqp::value::Value>>, cancel: CancellationToken) {
+        loop {
+            if cancel.is_cancelled() {
+                return;
+            }
+            trace!("Initiate amqp connection");
+            //Let's use the token for a day
+            //let sas_token_duration = Duration::from_secs(60 * 60 * 24);
+            let sas_token_duration = Duration::from_secs(245);
+            // after 4 min of inactivity, the connection is broken
+            let event_pubsub_connection_duration = Duration::from_millis(240000);
+            let mut start = Instant::now();
+            let mut last_receive_message = Instant::now();
+
+            match connectivity.connect(&parameters, sas_token_duration.clone()).await {
+                Ok(_) => {}
+                Err(e) => {
+                    error!("cant connect, let's try later {:?}",e);
+                    thread::sleep(Duration::from_secs(10));
+                    continue;
+                }
+            };
+
+            let mut reconnect = false;
+            loop {
+                if cancel.is_cancelled() {
+                    return;
+                }
+
+                let check_sas_duration = start.elapsed();
+                if check_sas_duration >= (sas_token_duration - event_pubsub_connection_duration) {
+                    trace!("sas about to expire, needs reconnection");
+                    reconnect = true;
+                }
+
+                let check_last_message_duration = last_receive_message.elapsed();
+                if check_last_message_duration >= event_pubsub_connection_duration - Duration::from_secs(10) {
+                    trace!("no message for the connection duration, needs reconnection");
+                    reconnect = true;
+                }
+
+                if reconnect {
+                    trace!("Reconnect amqp client");
+                    match connectivity.reconnect(&parameters, sas_token_duration.clone()).await {
+                        Ok(_) => {
+                            if cancel.is_cancelled() {
+                                return;
+                            }
+                        }
+                        Err(e) => {
+                            if cancel.is_cancelled() {
+                                return;
+                            }
+                            error!("cant reconnect, let's try to wait {:?}",e);
+                            thread::sleep(Duration::from_secs(2));
+                            continue;
+                        }
+                    };
+                    reconnect = false;
+                    start = Instant::now();
+                    last_receive_message = Instant::now();
+                }
+
+                let message = match rx.recv_timeout(Duration::from_secs(10)) {
+                    Ok(message) => {
+                        if cancel.is_cancelled() {
+                            return;
+                        }
+                        message
+                    }
+                    Err(_) => {
+                        if cancel.is_cancelled() {
+                            return;
+                        }
+                        reconnect = true;
+                        trace!("Inactivity occured, set reconnection");
+                        continue;
+                    }
+                };
+
+                match connectivity.send(message).await {
+                    Ok(_) => {
+                        if cancel.is_cancelled() {
+                            return;
+                        }
+                    }
+                    Err(e) => {
+                        if cancel.is_cancelled() {
+                            return;
+                        }
+                        reconnect = true;
+                        error!("cant send message, reconnect {:?}",e);
+                        continue;
+                    }
+                };
+            }
+        }
+    }
+
+
+    async fn run_uplink(region: String, region_common_name: CommonName, event_information: EventConnectionInformation) {
+        let mut uplink_client = AzureKafkaClient::new(region.as_str(), &event_information).await.expect("can't init azure client");
+        loop {
+            match uplink_client.consumer.as_ref().unwrap().recv().await {
+                Err(e) => {
+                    error!("Kafka error, rebuilding the client: {}", e);
+                    uplink_client = AzureKafkaClient::new(region.as_str(), &event_information).await.expect("can't init azure client");
+                    continue;
+                }
+                Ok(m) => {
+                    match uplink_client.process(&m).await {
+                        Err(e) => {
+                            error!("error when processing message and retrieving payload: {}", e);
+                        }
+                        Ok(payload) => {
+                            match Self::check_payload_and_callback(payload) {
+                                Ok(m) => {
+                                    let payload_decode_array: &[u8] = &m.payload;
+                                    let region = region.clone();
+                                    message_callback(region_common_name, payload_decode_array, region.as_str(), m.topic.as_str()).await;
+                                    trace!("message has been processed");
+                                    continue;
+                                }
+                                Err(err) => {
+                                    error!("Problem processing msg {:?}",err);
+                                    continue;
+                                }
+                            }
+                        }
+                    };
+                }
+            };
+        }
+    }
+
+    fn check_payload_and_callback(payload: &str) -> Result<MessageProperties, Error> {
+        type Err = Error;
+        let topic: &str;
+        info!("payload: '{}'",payload);
+        let msg: Value = serde_json::from_str(payload).unwrap_or_default();
+        let gateway_id = match msg[0]["data"]["systemProperties"]["iothub-connection-device-id"].as_str() {
+            Some(s) => s,
+            None => ""
+        };
+        let payload = match msg[0]["data"]["body"].as_str() {
+            Some(s) => s,
+            None => return Err(anyhow!("Payload does not exist"))
+        };
+        let payload = payload.as_bytes();
+        trace!("gateway_id {}", gateway_id);
+        let payload_decode = match decode(payload) {
+            Ok(vec) => vec,
+            Err(err) => {
+                return Err(anyhow!("Problem decoding payload in base64: {:?}", err));
+            }
+        };
+        if msg[0]["data"]["properties"]["up"].as_str().is_some() {
+            topic = "up";
+        } else if msg[0]["data"]["properties"]["ack"].as_str().is_some() {
+            topic = "ack";
+        } else if msg[0]["data"]["properties"]["stats"].as_str().is_some() {
+            topic = "stats";
+        } else {
+            return Err(anyhow!("Problem retrieving topic"));
+        }
+        Ok(MessageProperties {
+            payload: payload_decode,
+            topic: topic.to_string(),
+        })
+    }
+}
+
+fn build_bus_connection_string(azure_connection_string: String) -> Result<BusConnectionInformation> {
+    let mut hostname = "";
+    let mut shared_access_key_name = "";
+    let mut shared_access_key = "";
+    for key_value in azure_connection_string.split(";") {
+        let mut spl = key_value.split("=");
+        let key_option = spl.next();
+        let value_option = spl.next();
+        if key_option.is_none() || value_option.is_none() {
+            continue;
+        }
+        let key = key_option.unwrap();
+        let value = value_option.unwrap();
+        if key == "HostName" {
+            hostname = value;
+        } else if key == "SharedAccessKeyName" {
+            shared_access_key_name = value;
+        } else if key == "SharedAccessKey" {
+            shared_access_key = value;
+        }
+    }
+    let mut hostname_split = hostname.split(".");
+    let hub_name = hostname_split.next();
+    if hub_name.is_none() {
+        error!("no hubname");
+    }
+    Ok(BusConnectionInformation {
+        shared_access_key_name: format!("{}@sas.root.{}", shared_access_key_name, hub_name.unwrap()),
+        hostname: hostname.to_string(),
+        shared_access_key: shared_access_key.to_string(),
+    })
+}
+
+fn build_event_connection_string(azure_connection_string: String) -> Result<EventConnectionInformation> {
+    let mut hostname = "".to_string();
+    let mut topic_name = "".to_string();
+    for key_value in azure_connection_string.split(";") {
+        let mut spl = key_value.split("=");
+        let key_option = spl.next();
+        let value_option = spl.next();
+        if key_option.is_none() || value_option.is_none() {
+            continue;
+        }
+        let key = key_option.unwrap();
+        let value = value_option.unwrap().to_string();
+        if key == "Endpoint" {
+            let first_replace = value.replace("sb://", "").replace("/", "");
+            hostname = first_replace.as_str().to_string();
+        }
+        if key == "EntityPath" {
+            topic_name = value.as_str().to_string();
+        }
+    }
+    let mut hostname_split = hostname.split(".");
+    let hub_name = hostname_split.next();
+    if hub_name.is_none() {
+        error!("no hubname");
+    }
+    Ok(EventConnectionInformation {
+        connection_string: azure_connection_string,
+        hub_name: hub_name.unwrap().to_string(),
+        topic_name,
+    })
+}
+
+#[async_trait]
+impl GatewayBackend for AzureBackend {
+    async fn send_downlink(&self, df: &chirpstack_api::gw::DownlinkFrame) -> Result<()> {
+        COMMAND_COUNTER
+            .get_or_create(&CommandLabels {
+                command: "down".to_string(),
+            })
+            .inc();
+        info!("message: {:?}",df);
+
+
+        let mut df = df.clone();
+        df.v4_migrate();
+
+        let json = gateway_is_json(&df.gateway_id);
+        let b = match json {
+            true => serde_json::to_vec(&df).unwrap(),
+            false => df.encode_to_vec(),
+        };
+
+        let topic = format!("/devices/{}/messages/devicebound", &df.gateway_id);
+        #[cfg(not(test))]
+        info!(gateway_id = %df.gateway_id, topic = %topic, json = json, "Sending downlink frame");
+        #[cfg(test)]
+        info!("Sending downlink frame");
+
+        let message_id = Uuid::new_v4();
+        // All of the Microsoft AMQP clients represent the event body as an uninterpreted bag of bytes.
+        let data = b.to_bytes();
+
+        let message = AmqpMessage::builder()
+            .properties(Properties::builder()
+                .message_id(message_id.to_string())
+                .to(topic)
+                .build())
+            .application_properties(ApplicationProperties::builder()
+                .insert("iothub-ack", "none")
+                .insert("command", "down")
+                .build()
+            )
+            .data(Binary::from(data))
+            .build();
+
+        match self.tx.as_ref().unwrap().send(message) {
+            Err(err) => {
+                error!("{:?}",err)
+            }
+            _ => {}
+        };
+
+
+        Ok(())
+    }
+
+    async fn send_configuration(&self, gw_conf: &chirpstack_api::gw::GatewayConfiguration) -> Result<()> {
+        let json = gateway_is_json(&gw_conf.gateway_id);
+        let b = match json {
+            true => serde_json::to_vec(&gw_conf)?,
+            false => gw_conf.encode_to_vec(),
+        };
+
+        let topic = format!("/devices/{}/messages/devicebound", &gw_conf.gateway_id);
+        #[cfg(test)]
+        info!("Sending gateway configuration");
+        #[cfg(not(test))]
+        info!(gateway_id = %gw_conf.gateway_id, topic = %topic, json = json, "Sending gateway configuration");
+
+        let message_id = Uuid::new_v4();
+        // All of the Microsoft AMQP clients represent the event body as an uninterpreted bag of bytes.
+        let data = b.to_bytes();
+
+        let message = AmqpMessage::builder()
+            .properties(Properties::builder()
+                .message_id(message_id.to_string())
+                .to(topic)
+                .build())
+            .application_properties(ApplicationProperties::builder()
+                .insert("iothub-ack", "none")
+                .insert("command", "config")
+                .build()
+            )
+            .data(Binary::from(data))
+            .build();
+
+        match self.tx.as_ref().unwrap().send(message) {
+            Err(err) => {
+                error!("{:?}",err)
+            }
+            _ => {}
+        };
+
+        Ok(())
+    }
+}
+
+impl AzureKafkaClient {
+    pub async fn new(region: &str, parameters: &EventConnectionInformation) -> Result<AzureKafkaClient> {
+        let consumer: StreamConsumer = ClientConfig::new()
+            .set("bootstrap.servers", format!("{}.servicebus.windows.net:9093", &parameters.hub_name))
+            .set("security.protocol", "SASL_SSL")
+            .set("sasl.mechanisms", "PLAIN")
+            .set("sasl.username", "$ConnectionString")
+            .set("sasl.password", &parameters.connection_string)
+            .set("group.id", region)
+            .create()
+            .expect("Consumer creation failed");
+        consumer.subscribe(&[&parameters.topic_name])
+            .expect("Can't subscribe to topic");
+
+        let azure_client = AzureKafkaClient {
+            consumer: Some(consumer),
+        };
+        Ok(azure_client)
+    }
+
+    pub async fn process<'a>(&'a self, m: &'a BorrowedMessage<'_>) -> Result<&str> {
+        let payload = match m.payload_view::<str>() {
+            None => "",
+            Some(Ok(s)) => s,
+            Some(Err(e)) => {
+                error!("Error while deserializing message payload: {:?}", e);
+                ""
+            }
+        };
+        trace!("key: '{:?}', topic: {}, partition: {}, offset: {}, timestamp: {:?}",
+                 m.key(), m.topic(), m.partition(), m.offset(), m.timestamp());
+        self.consumer.as_ref().unwrap().commit_message(&m, CommitMode::Async).unwrap();
+        Ok(payload)
+    }
+}
+
+fn create_sas_token(
+    hostname: &str,
+    key_name: &str,
+    key: &str,
+    expiration: &SystemTime,
+) -> Result<String> {
+    type HmacSha256 = Hmac<Sha256>;
+    let encoded_url = urlencoding::encode(&hostname);
+    let exp = expiration.duration_since(UNIX_EPOCH).unwrap().as_secs();
+
+    let sig = format!("{}\n{}", encoded_url, exp);
+    let x = sig.as_bytes();
+    println!("{:?}", x);
+    let vec = base64::decode(key.as_bytes()).unwrap();
+    let key_decode = vec.to_bytes();
+    let mut m = HmacSha256::new_from_slice(key_decode)?;
+
+    m.update(x);
+    let result = base64::encode(m.finalize().into_bytes());
+
+    let hash = urlencoding::encode(&result);
+
+    Ok(format!(
+        "SharedAccessSignature sr={}&sig={}&se={}&skn={}",
+        encoded_url, hash, exp, key_name
+    ))
+}
+
+#[cfg(test)]
+pub mod test {
+    use tokio_util::sync::CancellationToken;
+
+    use super::*;
+
+    struct MockAmqpConnectivity {
+        mock_connect_fn: fn(parameters: &BusConnectionInformation, duration: Duration) -> Result<()>,
+        mock_reconnect_fn: fn(parameters: &BusConnectionInformation, duration: Duration) -> Result<()>,
+        mock_send_fn: fn(message: AmqpMessage<serde_amqp::Value>) -> Result<()>,
+        call_connect_tx: Option<ChanSender<bool>>,
+        call_reconnect_tx: Option<ChanSender<bool>>,
+        call_send_tx: Option<ChanSender<bool>>,
+    }
+
+    #[async_trait]
+    impl SendConnectivity<AmqpMessage<serde_amqp::value::Value>> for MockAmqpConnectivity {
+        async fn connect(&mut self, parameters: &BusConnectionInformation, duration: Duration) -> Result<()> {
+            if self.call_connect_tx.is_some() {
+                self.call_connect_tx.as_ref().unwrap().send(true).expect("TODO: panic message");
+            }
+            return (self.mock_connect_fn)(parameters, duration);
+        }
+
+        async fn reconnect(&mut self, parameters: &BusConnectionInformation, duration: Duration) -> Result<()> {
+            if self.call_reconnect_tx.is_some() {
+                self.call_reconnect_tx.as_ref().unwrap().send(true).expect("TODO: panic message");
+            }
+            return (self.mock_reconnect_fn)(parameters, duration);
+        }
+
+        async fn send(&mut self, message: AmqpMessage<serde_amqp::Value>) -> Result<()> {
+            if self.call_send_tx.is_some() {
+                self.call_send_tx.as_ref().unwrap().send(true).expect("TODO: panic message");
+            }
+            return (self.mock_send_fn)(message);
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_downlink_connect() {
+        let info = BusConnectionInformation {
+            shared_access_key: "a share key".to_string(),
+            hostname: "a hostname".to_string(),
+            shared_access_key_name: "a share access key name".to_string(),
+        };
+
+        let (_tx, rx): (ChanSender<AmqpMessage<serde_amqp::value::Value>>, ChanRceiver<AmqpMessage<serde_amqp::value::Value>>) = mpsc::sync_channel(1);
+        let (call_connect_tx, call_connect_rx): (ChanSender<bool>, ChanRceiver<bool>) = mpsc::sync_channel(1);
+        let mock_box = Box::new(MockAmqpConnectivity {
+            mock_connect_fn: |_info: &BusConnectionInformation, _d: Duration| {
+                Ok(())
+            },
+            mock_reconnect_fn: |_info, _d: Duration| {
+                Ok(())
+            },
+            mock_send_fn: |_message| {
+                Ok(())
+            },
+            call_connect_tx: Some(call_connect_tx),
+            call_reconnect_tx: None,
+            call_send_tx: None,
+
+        });
+
+        let token = CancellationToken::new();
+        let cloned_token = token.clone();
+        tokio::spawn(async move {
+            AzureBackend::run_downlink(mock_box, info, rx, cloned_token).await
+        });
+        let result = call_connect_rx.recv_timeout(Duration::from_secs(2));
+        token.cancel();
+
+        assert_eq!(result.is_err(), false);
+        assert_eq!(result.unwrap(), true);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_downlink_process_message() {
+        let (tx, rx): (ChanSender<AmqpMessage<serde_amqp::value::Value>>, ChanRceiver<AmqpMessage<serde_amqp::value::Value>>) = mpsc::sync_channel(1);
+        let (call_connect_tx, call_connect_rx): (ChanSender<bool>, ChanRceiver<bool>) = mpsc::sync_channel(1);
+        let (call_send_tx, call_send_rx): (ChanSender<bool>, ChanRceiver<bool>) = mpsc::sync_channel(1);
+        let mock_box = Box::new(MockAmqpConnectivity {
+            mock_connect_fn: |_info: &BusConnectionInformation, _d: Duration| {
+                Ok(())
+            },
+            mock_reconnect_fn: |_info, _d: Duration| {
+                Ok(())
+            },
+            mock_send_fn: |_message| {
+                Ok(())
+            },
+            call_connect_tx: Some(call_connect_tx),
+            call_reconnect_tx: None,
+            call_send_tx: Some(call_send_tx),
+
+        });
+        let info = BusConnectionInformation {
+            shared_access_key: "a share key".to_string(),
+            hostname: "a hostname".to_string(),
+            shared_access_key_name: "a share access key name".to_string(),
+        };
+        let token = CancellationToken::new();
+        let cloned_token = token.clone();
+        tokio::spawn(async move {
+            AzureBackend::run_downlink(mock_box, info, rx, cloned_token).await
+        });
+        let result = call_connect_rx.recv_timeout(Duration::from_secs(2));
+
+        assert_eq!(result.is_err(), false);
+        assert_eq!(result.unwrap(), true);
+
+
+        let handle = tokio::spawn(async move {
+            let result = call_send_rx.recv_timeout(Duration::from_secs(20));
+            if result.is_err() {
+                info!("{:?}",result.err())
+            }
+            assert_eq!(result.is_err(), false);
+            assert_eq!(result.unwrap(), true);
+        });
+
+        let message = AmqpMessage::builder().data(Binary::from("test".to_bytes())).build();
+        tx.send(message).expect("problem");
+
+        thread::sleep(Duration::from_secs(2));
+
+        handle.abort();
+        token.cancel();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_downlink_needs_reconnect() {
+        let (tx, rx): (ChanSender<AmqpMessage<serde_amqp::value::Value>>, ChanRceiver<AmqpMessage<serde_amqp::value::Value>>) = mpsc::sync_channel(1);
+        let (call_connect_tx, call_connect_rx): (ChanSender<bool>, ChanRceiver<bool>) = mpsc::sync_channel(1);
+        let (call_reconnect_tx, call_reconnect_rx): (ChanSender<bool>, ChanRceiver<bool>) = mpsc::sync_channel(1);
+        let (call_send_tx, call_send_rx): (ChanSender<bool>, ChanRceiver<bool>) = mpsc::sync_channel(1);
+        let mock_box = Box::new(MockAmqpConnectivity {
+            mock_connect_fn: |_info: &BusConnectionInformation, _d: Duration| {
+                Ok(())
+            },
+            mock_reconnect_fn: |_info, _d: Duration| {
+                Ok(())
+            },
+            mock_send_fn: |_message| {
+                return Err(Error::msg("problem"));
+            },
+            call_connect_tx: Some(call_connect_tx),
+            call_reconnect_tx: Some(call_reconnect_tx),
+            call_send_tx: Some(call_send_tx),
+
+        });
+        let info = BusConnectionInformation {
+            shared_access_key: "a share key".to_string(),
+            hostname: "a hostname".to_string(),
+            shared_access_key_name: "a share access key name".to_string(),
+        };
+        let token = CancellationToken::new();
+        let cloned_token = token.clone();
+        tokio::spawn(async move {
+            AzureBackend::run_downlink(mock_box, info, rx, cloned_token).await
+        });
+        let result = call_connect_rx.recv_timeout(Duration::from_secs(2));
+
+        assert_eq!(result.is_err(), false);
+        assert_eq!(result.unwrap(), true);
+
+
+        let handle_send = tokio::spawn(async move {
+            let result = call_send_rx.recv_timeout(Duration::from_secs(20));
+            if result.is_err() {
+                info!("{:?}",result.err())
+            }
+            assert_eq!(result.is_err(), false);
+            assert_eq!(result.unwrap(), true);
+        });
+
+        let handle_reconnect = tokio::spawn(async move {
+            let result = call_reconnect_rx.recv_timeout(Duration::from_secs(20));
+            if result.is_err() {
+                info!("{:?}",result.err())
+            }
+            assert_eq!(result.is_err(), false);
+            assert_eq!(result.unwrap(), true);
+        });
+
+        let message = AmqpMessage::builder().data(Binary::from("test".to_bytes())).build();
+        tx.send(message).expect("problem");
+
+        thread::sleep(Duration::from_secs(2));
+
+        handle_send.abort();
+        handle_reconnect.abort();
+        token.cancel();
+    }
+
+    #[test]
+    fn test_check_payload_and_callback_ok() {
+        let callback = AzureBackend::check_payload_and_callback(r#"[{"id":"47b0b740-8c32-1d88-b84b-343c765f11d8","topic":"/SUBSCRIPTIONS/D2037D29-C0F0-4E03-8E1E-87A0BFEAF16F/RESOURCEGROUPS/TEST/PROVIDERS/MICROSOFT.DEVICES/IOTHUBS/HIBER-TEST-HUB","subject":"devices/test-cecile","eventType":"Microsoft.Devices.DeviceTelemetry","data":{"properties":{"event_type":"up","region":"eu868"},"systemProperties":{"iothub-connection-device-id":"test-cecile","iothub-connection-auth-method":"{\"scope\":\"device\",\"type\":\"sas\",\"issuer\":\"iothub\",\"acceptingIpFilterRule\":null}","iothub-connection-auth-generation-id":"637968607726449711","iothub-enqueuedtime":"2022-09-13T13:41:36.7740000Z","iothub-message-source":"Telemetry"},"body":"aGVsbG8="},"dataVersion":"","metadataVersion":"1","eventTime":"2022-09-13T13:41:36.774Z"}]
+"#).unwrap();
+        assert_eq!(callback.region_name, "eu868");
+        assert_eq!(callback.topic, "up");
+        assert_eq!(callback.payload, decode(b"aGVsbG8=").unwrap());
+    }
+
+    #[test]
+    fn test_check_payload_and_callback_no_region() {
+        let callback_err = AzureBackend::check_payload_and_callback(r#"[{"id":"47b0b740-8c32-1d88-b84b-343c765f11d8","topic":"/SUBSCRIPTIONS/D2037D29-C0F0-4E03-8E1E-87A0BFEAF16F/RESOURCEGROUPS/TEST/PROVIDERS/MICROSOFT.DEVICES/IOTHUBS/HIBER-TEST-HUB","subject":"devices/test-cecile","eventType":"Microsoft.Devices.DeviceTelemetry","data":{"properties":{"event_type":"up"},"systemProperties":{"iothub-connection-device-id":"test-cecile","iothub-connection-auth-method":"{\"scope\":\"device\",\"type\":\"sas\",\"issuer\":\"iothub\",\"acceptingIpFilterRule\":null}","iothub-connection-auth-generation-id":"637968607726449711","iothub-enqueuedtime":"2022-09-13T13:41:36.7740000Z","iothub-message-source":"Telemetry"},"body":"aGVsbG8="},"dataVersion":"","metadataVersion":"1","eventTime":"2022-09-13T13:41:36.774Z"}]
+"#).err();
+        assert_eq!(callback_err.is_some(), true);
+    }
+
+    #[test]
+    fn test_check_payload_and_callback_no_event_type() {
+        let callback_err = AzureBackend::check_payload_and_callback(r#"[{"id":"47b0b740-8c32-1d88-b84b-343c765f11d8","topic":"/SUBSCRIPTIONS/D2037D29-C0F0-4E03-8E1E-87A0BFEAF16F/RESOURCEGROUPS/TEST/PROVIDERS/MICROSOFT.DEVICES/IOTHUBS/HIBER-TEST-HUB","subject":"devices/test-cecile","eventType":"Microsoft.Devices.DeviceTelemetry","data":{"properties":{"region":"eu868"},"systemProperties":{"iothub-connection-device-id":"test-cecile","iothub-connection-auth-method":"{\"scope\":\"device\",\"type\":\"sas\",\"issuer\":\"iothub\",\"acceptingIpFilterRule\":null}","iothub-connection-auth-generation-id":"637968607726449711","iothub-enqueuedtime":"2022-09-13T13:41:36.7740000Z","iothub-message-source":"Telemetry"},"body":"aGVsbG8="},"dataVersion":"","metadataVersion":"1","eventTime":"2022-09-13T13:41:36.774Z"}]
+"#).err();
+        assert_eq!(callback_err.is_some(), true);
+    }
+
+    #[test]
+    fn test_build_bus_connection_string() {
+        let connection_information = build_bus_connection_string("HostName=an-iot-hub.azure-devices.net;SharedAccessKeyName=service;SharedAccessKey=yuui58399mfCvhRvmowieujbsdsd".to_string()).unwrap();
+        assert_eq!(connection_information.hostname, "an-iot-hub.azure-devices.net");
+        assert_eq!(connection_information.shared_access_key_name, "service@sas.root.an-iot-hub");
+        assert_eq!(connection_information.shared_access_key, "yuui58399mfCvhRvmowieujbsdsd");
+    }
+
+    #[test]
+    fn test_build_event_connection_string() {
+        let connection_information = build_event_connection_string("Endpoint=sb://an-event-hub.servicebus.windows.net/;SharedAccessKeyName=a_key;SharedAccessKey=uuuuuuuuuuuuuuu;EntityPath=an_entity".to_string()).unwrap();
+        assert_eq!(connection_information.hub_name, "an-event-hub");
+        assert_eq!(connection_information.connection_string, "Endpoint=sb://an-event-hub.servicebus.windows.net/;SharedAccessKeyName=a_key;SharedAccessKey=uuuuuuuuuuuuuuu;EntityPath=an_entity");
+        assert_eq!(connection_information.topic_name, "an_entity");
+    }
+}

--- a/chirpstack/src/gateway/backend/common.rs
+++ b/chirpstack/src/gateway/backend/common.rs
@@ -1,0 +1,190 @@
+use std::collections::hash_map::DefaultHasher;
+use std::collections::HashMap;
+use std::hash::Hasher;
+use std::io::Cursor;
+use std::str;
+use std::sync::RwLock;
+
+use anyhow::Result;
+use prometheus_client::encoding::text::Encode;
+use prometheus_client::metrics::counter::Counter;
+use prometheus_client::metrics::family::Family;
+use prost::Message;
+use tokio::task;
+use tracing::{error, info, trace};
+
+use lrwn::region::CommonName;
+
+use crate::{downlink, uplink};
+use crate::monitoring::prometheus;
+use crate::storage::{get_redis_conn, redis_key};
+
+lazy_static! {
+    pub static ref EVENT_COUNTER: Family<EventLabels, Counter> = {
+        let counter = Family::<EventLabels, Counter>::default();
+        prometheus::register(
+            "gateway_backend_mqtt_events",
+            "Number of events received",
+            Box::new(counter.clone()),
+        );
+        counter
+    };
+  pub static ref COMMAND_COUNTER: Family<CommandLabels, Counter> = {
+        let counter = Family::<CommandLabels, Counter>::default();
+        prometheus::register(
+            "gateway_backend_mqtt_commands",
+            "Number of commands sent",
+            Box::new(counter.clone()),
+        );
+        counter
+    };
+    static ref GATEWAY_JSON: RwLock<HashMap<String, bool>> = RwLock::new(HashMap::new());
+}
+#[derive(Clone, Hash, PartialEq, Eq, Encode)]
+pub struct EventLabels {
+    event: String,
+}
+
+#[derive(Clone, Hash, PartialEq, Eq, Encode)]
+pub struct CommandLabels {
+    pub command: String,
+}
+
+pub async fn message_callback(region_common_name: CommonName, payload: &[u8], region_name: &str, topic: &str) {
+    let mut hasher = DefaultHasher::new();
+    hasher.write(payload);
+    let key = redis_key(format!("gw:mqtt:lock:{:x}", hasher.finish()));
+    let locked = is_locked(key).await;
+
+    match manage_message(&region_common_name, &payload, region_name, topic, locked) {
+        Ok(()) => (),
+        Err(err) =>   error!(
+            topic = topic,
+            "Processing gateway event error: {}",
+            err
+        ),
+    };
+}
+
+fn manage_message(region_common_name: &CommonName, payload: &&[u8], region_name: &str, topic: &str, locked: Result<bool>) -> Result<(),anyhow::Error> {
+    if locked? {
+        trace!(
+                region_name = region_name,
+                topic = topic,
+                "Message is already handled by different instance"
+            );
+        return Ok(());
+    }
+
+    let json = payload_is_json(payload);
+
+    info!(
+            region_name = region_name,
+            topic = topic,
+            json = json,
+            "Message received from gateway"
+        );
+
+    if topic.eq("up") {
+        EVENT_COUNTER
+            .get_or_create(&EventLabels {
+                event: "up".to_string(),
+            })
+            .inc();
+        let mut event = match json {
+            true => serde_json::from_slice(payload)?,
+            false => chirpstack_api::gw::UplinkFrame::decode(&mut Cursor::new(payload))?,
+        };
+        event.v4_migrate();
+
+        if let Some(rx_info) = &mut event.rx_info {
+            set_gateway_json(&rx_info.gateway_id, json);
+            rx_info.set_metadata_string("region_name", region_name);
+            rx_info.set_metadata_string("region_common_name", &region_common_name.to_string());
+        }
+
+        tokio::spawn(uplink::deduplicate_uplink(event));
+    } else if topic.eq("stats") {
+        EVENT_COUNTER
+            .get_or_create(&EventLabels {
+                event: "stats".to_string(),
+            })
+            .inc();
+        let mut event = match json {
+            true => serde_json::from_slice(payload)?,
+            false => chirpstack_api::gw::GatewayStats::decode(&mut Cursor::new(payload))?,
+        };
+        event.v4_migrate();
+        event
+            .meta_data
+            .insert("region_name".to_string(), region_name.to_string());
+        event.meta_data.insert(
+            "region_common_name".to_string(),
+            region_common_name.to_string(),
+        );
+        set_gateway_json(&event.gateway_id, json);
+        tokio::spawn(uplink::stats::Stats::handle(event));
+    } else if topic.eq("ack") {
+        EVENT_COUNTER
+            .get_or_create(&EventLabels {
+                event: "ack".to_string(),
+            })
+            .inc();
+        let mut event = match json {
+            true => serde_json::from_slice(payload)?,
+            false => chirpstack_api::gw::DownlinkTxAck::decode(&mut Cursor::new(payload))?,
+        };
+        event.v4_migrate();
+        set_gateway_json(&event.gateway_id, json);
+        tokio::spawn(downlink::tx_ack::TxAck::handle(event));
+    } else {
+        return Err(anyhow!("Unknown event type"));
+    }
+
+    Ok(())
+}
+
+async fn is_locked(key: String) -> Result<bool> {
+    task::spawn_blocking({
+        move || -> Result<bool> {
+            let mut c = get_redis_conn()?;
+
+            let set: bool = redis::cmd("SET")
+                .arg(key)
+                .arg("lock")
+                .arg("PX")
+                .arg(5000)
+                .arg("NX")
+                .query(&mut *c)?;
+
+            Ok(!set)
+        }
+    })
+        .await?
+}
+
+fn payload_is_json(b: &[u8]) -> bool {
+    String::from_utf8_lossy(b).contains("gatewayId")
+}
+
+fn set_gateway_json(gateway_id: &str, is_json: bool) {
+    let mut gw_json_w = GATEWAY_JSON.write().unwrap();
+    gw_json_w.insert(gateway_id.to_string(), is_json);
+}
+
+pub fn gateway_is_json(gateway_id: &str) -> bool {
+    let gw_json_r = GATEWAY_JSON.read().unwrap();
+    gw_json_r.get(gateway_id).cloned().unwrap_or(false)
+}
+
+
+#[cfg(test)]
+pub mod test {
+    use super::*;
+
+    #[test]
+    fn test_is_json() {
+        let r = payload_is_json(b"{\"phyPayload\":\"ABkCMP7/49dgGQIw/v/j12ChxkpEVts=\",\"txInfo\":{\"frequency\":867500000,\"modulation\":{\"lora\":{\"bandwidth\":125000,\"spreadingFactor\":12,\"codeRate\":\"CR_4_5\"}}},\"rxInfo\":{\"gatewayId\":\"1000000000000009\",\"uplinkId\":64154,\"time\":\"2022-09-15T08:21:25.369388Z\",\"rssi\":-60,\"snr\":5.5,\"channel\":5,\"context\":\"AAAAAA==\"}}");
+        assert_eq!(r, true);
+    }
+}

--- a/chirpstack/src/gateway/backend/mod.rs
+++ b/chirpstack/src/gateway/backend/mod.rs
@@ -7,11 +7,11 @@ use tracing::{info, warn};
 
 use crate::config;
 
+mod azure;
+mod common;
 #[cfg(test)]
 pub mod mock;
 mod mqtt;
-mod azure;
-mod common;
 
 lazy_static! {
     static ref BACKENDS: RwLock<HashMap<String, Box<dyn GatewayBackend + Sync + Send>>> =
@@ -48,7 +48,9 @@ pub async fn setup() -> Result<()> {
                 &region.name,
                 region.common_name,
                 &region.gateway.backend.azure,
-            ).await.context("New MQTT gateway backend error")?;
+            )
+            .await
+            .context("New MQTT gateway backend error")?;
 
             set_backend(&region.name, Box::new(backend)).await;
         } else {
@@ -56,8 +58,9 @@ pub async fn setup() -> Result<()> {
                 &region.name,
                 region.common_name,
                 &region.gateway.backend.mqtt,
-            ).await
-                .context("New MQTT gateway backend error")?;
+            )
+            .await
+            .context("New MQTT gateway backend error")?;
             set_backend(&region.name, Box::new(backend)).await;
         }
     }

--- a/chirpstack/src/gateway/backend/mod.rs
+++ b/chirpstack/src/gateway/backend/mod.rs
@@ -10,6 +10,8 @@ use crate::config;
 #[cfg(test)]
 pub mod mock;
 mod mqtt;
+mod azure;
+mod common;
 
 lazy_static! {
     static ref BACKENDS: RwLock<HashMap<String, Box<dyn GatewayBackend + Sync + Send>>> =
@@ -38,18 +40,26 @@ pub async fn setup() -> Result<()> {
         info!(
             region_name = %region.name,
             region_common_name = %region.common_name,
+            backend_type = %region.gateway.backend.enabled,
             "Setting up gateway backend for region"
         );
+        if region.gateway.backend.enabled == "azure" {
+            let backend = azure::AzureBackend::new(
+                &region.name,
+                region.common_name,
+                &region.gateway.backend.azure,
+            ).await.context("New MQTT gateway backend error")?;
 
-        let backend = mqtt::MqttBackend::new(
-            &region.name,
-            region.common_name,
-            &region.gateway.backend.mqtt,
-        )
-        .await
-        .context("New MQTT gateway backend error")?;
-
-        set_backend(&region.name, Box::new(backend)).await;
+            set_backend(&region.name, Box::new(backend)).await;
+        } else {
+            let backend = mqtt::MqttBackend::new(
+                &region.name,
+                region.common_name,
+                &region.gateway.backend.mqtt,
+            ).await
+                .context("New MQTT gateway backend error")?;
+            set_backend(&region.name, Box::new(backend)).await;
+        }
     }
 
     Ok(())

--- a/chirpstack/src/gateway/backend/mqtt.rs
+++ b/chirpstack/src/gateway/backend/mqtt.rs
@@ -16,10 +16,10 @@ use lrwn::region::CommonName;
 
 use crate::config::GatewayBackendMqtt;
 
-use super::common::COMMAND_COUNTER;
-use super::common::CommandLabels;
 use super::common::gateway_is_json;
 use super::common::message_callback;
+use super::common::CommandLabels;
+use super::common::COMMAND_COUNTER;
 use super::GatewayBackend;
 
 struct MqttContext {
@@ -175,8 +175,14 @@ impl<'a> MqttBackend<'a> {
                         } else {
                             topic = "";
                         }
-                        trace!("mqtt_topic {}, region {}, qos {}", mqtt_topic,region_name,qos);
-                        message_callback(region_common_name, msg.payload(), &region_name, &topic).await;
+                        trace!(
+                            "mqtt_topic {}, region {}, qos {}",
+                            mqtt_topic,
+                            region_name,
+                            qos
+                        );
+                        message_callback(region_common_name, msg.payload(), &region_name, &topic)
+                            .await;
                     }
                 }
             }

--- a/chirpstack/src/main.rs
+++ b/chirpstack/src/main.rs
@@ -6,6 +6,7 @@ extern crate diesel_migrations;
 extern crate diesel;
 #[macro_use]
 extern crate anyhow;
+extern crate core;
 
 use std::path::Path;
 use std::process;


### PR DESCRIPTION
Good morning,

As I wrote in the ticket, here is my implementation of the azure support.
It uses a kafka client to fetch the gateway messages and an amqp client to push them back.
It works with EventGrid and event hub.

I let you decide if you want to integrate it.

Thanks again

Here is the configuration:
`    # Gateway backend configuration.
    [regions.gateway.backend]

      # The enabled backend type.
      enabled="azure"
      # Azure configuration.
      [regions.gateway.backend.azure]
        commands_connection_string="HostName=<HostName>-devices.net;SharedAccessKeyName=service;SharedAccessKey=<access_key>"
        events_connection_string= "Endpoint=sb://<eventhubname>.servicebus.windows.net/;SharedAccessKeyName=serviceSharedAccessKey=<access_key>;EntityPath=eventdirect"`