### PR TITLE
Update tenant.proto

### DIFF
--- a/api/proto/api/tenant.proto
+++ b/api/proto/api/tenant.proto
@@ -5,7 +5,7 @@ package api;
 option go_package = "github.com/chirpstack/chirpstack/api/go/v4/api";
 option java_package = "io.chirpstack.api";
 option java_multiple_files = true;
-option java_outer_classname = "InternalProto";
+option java_outer_classname = "TenantProto";
 
 import "google/api/annotations.proto";
 import "google/protobuf/timestamp.proto";


### PR DESCRIPTION
fix: Corrected the java_outer_classname to "TenantProto" to avoid conflict with original "InternalProto".