### PR TITLE
Emit integration fields in JSON if at a valid value that is also their default value.

### DIFF
--- a/api/rust/build.rs
+++ b/api/rust/build.rs
@@ -97,6 +97,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let descriptor_set = std::fs::read(out_dir.join("integration").join("proto_descriptor.bin"))?;
     pbjson_build::Builder::new()
+        .emit_fields()
         .register_descriptors(&descriptor_set)?
         .out_dir(out_dir.join("integration"))
         .extern_path(".common", "crate::common")


### PR DESCRIPTION
This change will cause fields to be emitted for JSON integration even if they are their default value. For example: before this change a valid data rate of 0 would be omitted from the messages from the integration JSON messages. With this change a valid value of 0 will not be omitted anymore.

This change is related to issue #43 

