### PR TITLE
Update US902-928 to right Downlink MinDR according to RP2-1.0.3

### DIFF
--- a/lrwn/src/region/us915.rs
+++ b/lrwn/src/region/us915.rs
@@ -642,7 +642,7 @@ impl Configuration {
         for i in 0..8 {
             c.base.downlink_channels.push(Channel {
                 frequency: 923300000 + (i * 600000),
-                min_dr: 10,
+                min_dr: 8,
                 max_dr: 13,
                 enabled: true,
                 user_defined: false,


### PR DESCRIPTION
RP2-1.0.3 defines that the MinDR for US902-928 is 8 (SF12BW500) not 10 (SF10BW500)