### PR TITLE
fix configfile command template

### DIFF
--- a/chirpstack/src/cmd/configfile.rs
+++ b/chirpstack/src/cmd/configfile.rs
@@ -382,8 +382,8 @@ pub fn run() {
       # will generate client certificates which can be used by the MQTT clients for
       # authentication and authorization. The Common Name of the certificate will
       # be set to the ID of the application.
-      ca_key="{{ integration.mqtt.ca_key }}"
-      ca_cert="{{ integration.mqtt.ca_cert }}"
+      ca_key="{{ integration.mqtt.client.ca_key }}"
+      ca_cert="{{ integration.mqtt.client.ca_cert }}"
 
       # Certificate lifetime.
       #


### PR DESCRIPTION
The template for the configfile command seems to be incorrect, as it uses `integration.mqtt.ca_key` and  `integration.mqtt.ca_cert` inside `[integration.mqtt.client]`, the command as it is always reports the wrong `integration.mqtt.client.ca_cert` (as it uses the one from `[integration.mqtt]` and empty `integration.mqtt.client.ca_key` (since `integration.mqtt.ca_key` does not exists)