### PR TITLE
re-export prost::Message

### DIFF
--- a/api/rust/src/lib.rs
+++ b/api/rust/src/lib.rs
@@ -1,4 +1,4 @@
-pub use prost::Message;
+pub use prost;
 #[cfg(feature = "api")]
 pub mod api;
 pub mod common;

--- a/api/rust/src/lib.rs
+++ b/api/rust/src/lib.rs
@@ -1,3 +1,4 @@
+pub use prost::Message;
 #[cfg(feature = "api")]
 pub mod api;
 pub mod common;


### PR DESCRIPTION
Allows for importing the message trait for Decoding without needing the add the same version of prost as a dependency.