### PR TITLE
remove trailing whitespace

### DIFF
--- a/chirpstack/configuration/region_as923.toml
+++ b/chirpstack/configuration/region_as923.toml
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=923200000
@@ -110,7 +110,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -189,12 +189,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=3
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_as923_2.toml
+++ b/chirpstack/configuration/region_as923_2.toml
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=921400000
@@ -110,7 +110,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -189,12 +189,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=3
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_as923_3.toml
+++ b/chirpstack/configuration/region_as923_3.toml
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=916600000
@@ -110,7 +110,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -189,12 +189,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=3
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_as923_4.toml
+++ b/chirpstack/configuration/region_as923_4.toml
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=917300000
@@ -110,7 +110,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -189,12 +189,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=3
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_au915_0.toml
+++ b/chirpstack/configuration/region_au915_0.toml
@@ -20,7 +20,7 @@
     # If enabled, gateways can only be used by devices under the same tenant.
     force_gws_private=false
 
-    
+
     # Gateway backend configuration.
     [regions.gateway.backend]
 
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=915200000
@@ -152,7 +152,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -238,12 +238,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=8
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_au915_1.toml
+++ b/chirpstack/configuration/region_au915_1.toml
@@ -20,7 +20,7 @@
     # If enabled, gateways can only be used by devices under the same tenant.
     force_gws_private=false
 
-    
+
     # Gateway backend configuration.
     [regions.gateway.backend]
 
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=916800000
@@ -152,7 +152,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -238,12 +238,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=8
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_au915_2.toml
+++ b/chirpstack/configuration/region_au915_2.toml
@@ -20,7 +20,7 @@
     # If enabled, gateways can only be used by devices under the same tenant.
     force_gws_private=false
 
-    
+
     # Gateway backend configuration.
     [regions.gateway.backend]
 
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=918400000
@@ -152,7 +152,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -238,12 +238,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=8
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_au915_3.toml
+++ b/chirpstack/configuration/region_au915_3.toml
@@ -20,7 +20,7 @@
     # If enabled, gateways can only be used by devices under the same tenant.
     force_gws_private=false
 
-    
+
     # Gateway backend configuration.
     [regions.gateway.backend]
 
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=920000000
@@ -152,7 +152,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -238,12 +238,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=8
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_au915_4.toml
+++ b/chirpstack/configuration/region_au915_4.toml
@@ -20,7 +20,7 @@
     # If enabled, gateways can only be used by devices under the same tenant.
     force_gws_private=false
 
-    
+
     # Gateway backend configuration.
     [regions.gateway.backend]
 
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=921600000
@@ -152,7 +152,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -238,12 +238,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=8
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_au915_5.toml
+++ b/chirpstack/configuration/region_au915_5.toml
@@ -20,7 +20,7 @@
     # If enabled, gateways can only be used by devices under the same tenant.
     force_gws_private=false
 
-    
+
     # Gateway backend configuration.
     [regions.gateway.backend]
 
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=923200000
@@ -152,7 +152,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -238,12 +238,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=8
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_au915_6.toml
+++ b/chirpstack/configuration/region_au915_6.toml
@@ -20,7 +20,7 @@
     # If enabled, gateways can only be used by devices under the same tenant.
     force_gws_private=false
 
-    
+
     # Gateway backend configuration.
     [regions.gateway.backend]
 
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=924800000
@@ -152,7 +152,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -238,12 +238,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=8
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_au915_7.toml
+++ b/chirpstack/configuration/region_au915_7.toml
@@ -20,7 +20,7 @@
     # If enabled, gateways can only be used by devices under the same tenant.
     force_gws_private=false
 
-    
+
     # Gateway backend configuration.
     [regions.gateway.backend]
 
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=926400000
@@ -152,7 +152,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -238,12 +238,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=8
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_cn470_0.toml
+++ b/chirpstack/configuration/region_cn470_0.toml
@@ -20,7 +20,7 @@
     # If enabled, gateways can only be used by devices under the same tenant.
     force_gws_private=false
 
-    
+
     # Gateway backend configuration.
     [regions.gateway.backend]
 
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=470300000
@@ -146,7 +146,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -232,12 +232,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=2
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_cn470_1.toml
+++ b/chirpstack/configuration/region_cn470_1.toml
@@ -20,7 +20,7 @@
     # If enabled, gateways can only be used by devices under the same tenant.
     force_gws_private=false
 
-    
+
     # Gateway backend configuration.
     [regions.gateway.backend]
 
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=471900000
@@ -146,7 +146,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -232,12 +232,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=2
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_cn470_10.toml
+++ b/chirpstack/configuration/region_cn470_10.toml
@@ -20,7 +20,7 @@
     # If enabled, gateways can only be used by devices under the same tenant.
     force_gws_private=false
 
-    
+
     # Gateway backend configuration.
     [regions.gateway.backend]
 
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=486300000
@@ -146,7 +146,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -232,12 +232,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=2
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_cn470_11.toml
+++ b/chirpstack/configuration/region_cn470_11.toml
@@ -20,7 +20,7 @@
     # If enabled, gateways can only be used by devices under the same tenant.
     force_gws_private=false
 
-    
+
     # Gateway backend configuration.
     [regions.gateway.backend]
 
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=487900000
@@ -146,7 +146,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -232,12 +232,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=2
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_cn470_2.toml
+++ b/chirpstack/configuration/region_cn470_2.toml
@@ -20,7 +20,7 @@
     # If enabled, gateways can only be used by devices under the same tenant.
     force_gws_private=false
 
-    
+
     # Gateway backend configuration.
     [regions.gateway.backend]
 
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=473500000
@@ -146,7 +146,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -232,12 +232,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=2
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_cn470_3.toml
+++ b/chirpstack/configuration/region_cn470_3.toml
@@ -20,7 +20,7 @@
     # If enabled, gateways can only be used by devices under the same tenant.
     force_gws_private=false
 
-    
+
     # Gateway backend configuration.
     [regions.gateway.backend]
 
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=475100000
@@ -146,7 +146,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -232,12 +232,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=2
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_cn470_4.toml
+++ b/chirpstack/configuration/region_cn470_4.toml
@@ -20,7 +20,7 @@
     # If enabled, gateways can only be used by devices under the same tenant.
     force_gws_private=false
 
-    
+
     # Gateway backend configuration.
     [regions.gateway.backend]
 
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=476700000
@@ -146,7 +146,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -232,12 +232,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=2
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_cn470_5.toml
+++ b/chirpstack/configuration/region_cn470_5.toml
@@ -20,7 +20,7 @@
     # If enabled, gateways can only be used by devices under the same tenant.
     force_gws_private=false
 
-    
+
     # Gateway backend configuration.
     [regions.gateway.backend]
 
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=478300000
@@ -146,7 +146,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -232,12 +232,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=2
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_cn470_6.toml
+++ b/chirpstack/configuration/region_cn470_6.toml
@@ -20,7 +20,7 @@
     # If enabled, gateways can only be used by devices under the same tenant.
     force_gws_private=false
 
-    
+
     # Gateway backend configuration.
     [regions.gateway.backend]
 
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=479900000
@@ -146,7 +146,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -232,12 +232,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=2
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_cn470_7.toml
+++ b/chirpstack/configuration/region_cn470_7.toml
@@ -20,7 +20,7 @@
     # If enabled, gateways can only be used by devices under the same tenant.
     force_gws_private=false
 
-    
+
     # Gateway backend configuration.
     [regions.gateway.backend]
 
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=481500000
@@ -146,7 +146,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -232,12 +232,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=2
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_cn470_8.toml
+++ b/chirpstack/configuration/region_cn470_8.toml
@@ -20,7 +20,7 @@
     # If enabled, gateways can only be used by devices under the same tenant.
     force_gws_private=false
 
-    
+
     # Gateway backend configuration.
     [regions.gateway.backend]
 
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=483100000
@@ -146,7 +146,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -232,12 +232,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=2
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_cn470_9.toml
+++ b/chirpstack/configuration/region_cn470_9.toml
@@ -20,7 +20,7 @@
     # If enabled, gateways can only be used by devices under the same tenant.
     force_gws_private=false
 
-    
+
     # Gateway backend configuration.
     [regions.gateway.backend]
 
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=484700000
@@ -146,7 +146,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -232,12 +232,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=2
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_cn779.toml
+++ b/chirpstack/configuration/region_cn779.toml
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=779500000
@@ -116,7 +116,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -195,12 +195,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=3
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_eu433.toml
+++ b/chirpstack/configuration/region_eu433.toml
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=433175000
@@ -116,7 +116,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -195,12 +195,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=3
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_eu868.toml
+++ b/chirpstack/configuration/region_eu868.toml
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=868100000
@@ -142,13 +142,13 @@
       bandwidth=125000
       modulation="LORA"
       spreading_factors=[7, 8, 9, 10, 11, 12]
-  
+
     [[regions.gateway.channels]]
       frequency=868300000
       bandwidth=250000
       modulation="LORA"
       spreading_factors=[7]
-    
+
     [[regions.gateway.channels]]
       frequency=868800000
       bandwidth=125000
@@ -158,7 +158,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -237,12 +237,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=3
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_in865.toml
+++ b/chirpstack/configuration/region_in865.toml
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=865062500
@@ -116,7 +116,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -195,12 +195,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=4
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_ism2400.toml
+++ b/chirpstack/configuration/region_ism2400.toml
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=2403000000
@@ -116,7 +116,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -195,12 +195,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=0
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_kr920.toml
+++ b/chirpstack/configuration/region_kr920.toml
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=922100000
@@ -116,7 +116,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -195,12 +195,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=3
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_ru864.toml
+++ b/chirpstack/configuration/region_ru864.toml
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=868900000
@@ -110,7 +110,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -189,12 +189,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=3
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_us915_0.toml
+++ b/chirpstack/configuration/region_us915_0.toml
@@ -20,7 +20,7 @@
     # If enabled, gateways can only be used by devices under the same tenant.
     force_gws_private=false
 
-    
+
     # Gateway backend configuration.
     [regions.gateway.backend]
 
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=902300000
@@ -152,7 +152,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -238,12 +238,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=8
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_us915_1.toml
+++ b/chirpstack/configuration/region_us915_1.toml
@@ -20,7 +20,7 @@
     # If enabled, gateways can only be used by devices under the same tenant.
     force_gws_private=false
 
-    
+
     # Gateway backend configuration.
     [regions.gateway.backend]
 
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=903900000
@@ -152,7 +152,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -238,12 +238,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=8
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_us915_2.toml
+++ b/chirpstack/configuration/region_us915_2.toml
@@ -20,7 +20,7 @@
     # If enabled, gateways can only be used by devices under the same tenant.
     force_gws_private=false
 
-    
+
     # Gateway backend configuration.
     [regions.gateway.backend]
 
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=905500000
@@ -152,7 +152,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -238,12 +238,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=8
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_us915_3.toml
+++ b/chirpstack/configuration/region_us915_3.toml
@@ -20,7 +20,7 @@
     # If enabled, gateways can only be used by devices under the same tenant.
     force_gws_private=false
 
-    
+
     # Gateway backend configuration.
     [regions.gateway.backend]
 
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=907100000
@@ -152,7 +152,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -238,12 +238,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=8
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_us915_4.toml
+++ b/chirpstack/configuration/region_us915_4.toml
@@ -20,7 +20,7 @@
     # If enabled, gateways can only be used by devices under the same tenant.
     force_gws_private=false
 
-    
+
     # Gateway backend configuration.
     [regions.gateway.backend]
 
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=908700000
@@ -152,7 +152,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -238,12 +238,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=8
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_us915_5.toml
+++ b/chirpstack/configuration/region_us915_5.toml
@@ -20,7 +20,7 @@
     # If enabled, gateways can only be used by devices under the same tenant.
     force_gws_private=false
 
-    
+
     # Gateway backend configuration.
     [regions.gateway.backend]
 
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=910300000
@@ -152,7 +152,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -238,12 +238,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=8
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_us915_6.toml
+++ b/chirpstack/configuration/region_us915_6.toml
@@ -20,7 +20,7 @@
     # If enabled, gateways can only be used by devices under the same tenant.
     force_gws_private=false
 
-    
+
     # Gateway backend configuration.
     [regions.gateway.backend]
 
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=911900000
@@ -152,7 +152,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -238,12 +238,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=8
 
       # Ping-slot frequency (Hz)

--- a/chirpstack/configuration/region_us915_7.toml
+++ b/chirpstack/configuration/region_us915_7.toml
@@ -20,7 +20,7 @@
     # If enabled, gateways can only be used by devices under the same tenant.
     force_gws_private=false
 
-    
+
     # Gateway backend configuration.
     [regions.gateway.backend]
 
@@ -93,7 +93,7 @@
     # Gateway channel configuration.
     #
     # Note: this configuration is only used in case the gateway is using the
-    # ChirpStack Concentratord daemon. In any other case, this configuration 
+    # ChirpStack Concentratord daemon. In any other case, this configuration
     # is ignored.
     [[regions.gateway.channels]]
       frequency=913500000
@@ -152,7 +152,7 @@
 
   # Region specific network configuration.
   [regions.network]
-    
+
     # Installation margin (dB) used by the ADR engine.
     #
     # A higher number means that the network-server will keep more margin,
@@ -238,12 +238,12 @@
       # 0  = roughly 17 minutes
       # 15 = about 1 year
       max_time_n=0
-    
+
 
     # Class-B configuration.
     [regions.network.class_b]
 
-      # Ping-slot data-rate. 
+      # Ping-slot data-rate.
       ping_slot_dr=8
 
       # Ping-slot frequency (Hz)


### PR DESCRIPTION
remove trailing whitespace. resolves breaking k8s `kubectl configmap create`