### PR TITLE
Add the misspelled UnkownReceiver as a valid ResultCode in BE

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -466,7 +466,7 @@ pub enum ResultCode {
     UnknownDevAddr,
     UnknownSender,
     UnknownReceiver,
-    UnkownReceiver,
+    UnkownReceiver, //Value in Backend Interfaces Spec 1.0/1.1 is misspelled
     Deferred,
     XmitFailed,
     InvalidFPort,

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -466,6 +466,7 @@ pub enum ResultCode {
     UnknownDevAddr,
     UnknownSender,
     UnknownReceiver,
+    UnkownReceiver,
     Deferred,
     XmitFailed,
     InvalidFPort,


### PR DESCRIPTION
UnknownReceiver in the BE Spec is unfortunately misspelled so this needs to be supported as well as the correct spelling.