### PR TITLE
Fix Chirpstack overwriting user updates by OIDC user provisioning callback

### DIFF
--- a/chirpstack/src/api/internal.rs
+++ b/chirpstack/src/api/internal.rs
@@ -64,7 +64,7 @@ impl Internal {
         }
 
         // fetch user again because the provisioning callback url may have updated the user.
-        u = user::get(&u.id).await.map_err(|e| e.status())?;
+        u = user::get(&u.id).await?;
 
         Ok(u)
     }


### PR DESCRIPTION
In the OIDC integration workflow, we can have a callback API registered (registration_callback_url). This callback is called to complete the provisioning of a new user, if registration is enabled.

However, Chirpstack would overwrite any changes made by this callback, as open_id_connect_login() re-saves the user after the provisioning callback returns. This PR restores what seems to be existing behaviour of Chirpstack v3, whereby the user is re-read after the callback returns first, before making any additional changes.

How to replicate the issue:
1. Have OIDC integration configured in Chirpstack, with this registration callback configured. The registration callback must update the user, such as making the user an administrator.
2. Attempt to log into Chirpstack, as a new user.
3. The registration callback is called, which attempts to make the user an administrator or to change other attributes.
4. After the user is created, note that the user is still not an administrator.

Related code in Chirpstack v3's Application Server: https://github.com/brocaar/chirpstack-application-server/blob/master/internal/api/external/internal.go#L324
```
...
				// we did not find the user by external_id or email and registration is enabled.
				if err == storage.ErrDoesNotExist && registrationEnabled {
					user, err = a.createAndProvisionUser(ctx, oidcUser)
					if err != nil {
						return nil, helpers.ErrToRPCError(err)
					}
					// fetch user again because the provisioning callback url may have updated the user.
					user, err = storage.GetUser(ctx, storage.DB(), user.ID)
					if err != nil {
						return nil, helpers.ErrToRPCError(err)
					}
				} else {
					return nil, helpers.ErrToRPCError(err)
				}
...
```

Since my background is in C and Java, I do apologize if the code quality is not up to standard.