### PR TITLE
Fix drawer header z-index issue in UI.

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -124,6 +124,7 @@ pre {
 
 .ant-drawer {
   padding-top: 64px;
+  z-index:1002;
 }
 
 .ant-drawer-body {


### PR DESCRIPTION
The z-index of the header was set to 1000 and the drawer header is behind the UI header so single frame download and title not displaying

Setting the z-index to 1002 is enough to fix the Drawer header issue

![image](https://github.com/chirpstack/chirpstack/assets/43664335/21d07e38-73a5-4d1e-988f-858290dc2cce)