### PR TITLE
empty shared_name disable shared_subscription

### DIFF
--- a/chirpstack/src/gateway/backend/mqtt.rs
+++ b/chirpstack/src/gateway/backend/mqtt.rs
@@ -185,7 +185,11 @@ impl<'a> MqttBackend<'a> {
             } else {
                 conf.event_topic.clone()
             };
-            let event_topic = format!("$share/{}/{}", conf.share_name, event_topic);
+            let event_topic = if conf.share_name.is_empty() {
+                event_topic
+            } else {
+                format!("$share/{}/{}", conf.share_name, event_topic)
+            };
 
             async move {
                 while connect_rx.recv().await.is_some() {


### PR DESCRIPTION
Hello Chirpstack Team

**My Problem :**
I see #407 and this [Chirpstack Forum](https://forum.chirpstack.io/t/chirpstack-4-7-0-mqtt-v3-support/18508/7)

Yes RabbitMQ 3.13 use MQTTv5 but shared subscriptions is not yet supported :
[RabbitMQ Blog](https://www.rabbitmq.com/blog/2023/07/21/mqtt5#shared-subscriptions)

In my stack I use chirpstack gateway bridge + chirpstack + RabbitMQ 3.13
But if we use shared subscription. I must config ChirpstackGatewayBridge, cause he use MQTT 3.1, 
like this 
```conf
event_topic_template="$share/chirpstack/eu868/gateway/{{ .GatewayID }}/event/{{ .EventType }}"
state_topic_template="$share/chirpstack/eu868/gateway/{{ .GatewayID }}/state/{{ .StateType }}"
```
Maybe a futur release of RabbitMQ change that and broke GatewayBridge.

**A Solution**
I edit mqtt.rs if share_name is empty I don't want to use share subscription feature else use it

Thanks for reading

PS: I can miss something in config
