### PR TITLE
Optimize python and md api build by adding `--depth=1` to git clones

### DIFF
--- a/api/Dockerfile-csharp
+++ b/api/Dockerfile-csharp
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 ENV PROJECT_PATH=/chirpstack/api
 
 RUN apt update && apt install -y make git
-RUN git clone --depth=1 --branch=master https://github.com/googleapis/googleapis.git /googleapis
+RUN git clone --depth=1 https://github.com/googleapis/googleapis.git /googleapis
 RUN mkdir -p /googleproto/google/api/
 RUN mv /googleapis/google/api/http.proto /googleproto/google/api/ && mv /googleapis/google/api/annotations.proto /googleproto/google/api/
 RUN rm -rf /googleapis

--- a/api/Dockerfile-md
+++ b/api/Dockerfile-md
@@ -3,7 +3,7 @@ FROM golang:1.19.3-alpine
 ENV PROJECT_PATH=/chirpstack/api
 RUN apk add --no-cache make git bash protobuf protobuf-dev
 
-RUN git clone https://github.com/googleapis/googleapis.git /googleapis
+RUN git clone --depth=1 https://github.com/googleapis/googleapis.git /googleapis
 
 RUN mkdir -p $PROJECT_PATH
 WORKDIR $PROJECT_PATH

--- a/api/Dockerfile-python
+++ b/api/Dockerfile-python
@@ -2,8 +2,8 @@ FROM python:3.11.0
 
 ENV PROJECT_PATH=/chirpstack/api
 
-RUN git clone https://github.com/protocolbuffers/protobuf.git /protobuf
-RUN git clone https://github.com/googleapis/googleapis.git /googleapis
+RUN git clone --depth=1 https://github.com/protocolbuffers/protobuf.git /protobuf
+RUN git clone --depth=1 https://github.com/googleapis/googleapis.git /googleapis
 
 RUN mkdir -p PROJECT_PATH
 WORKDIR $PROJECT_PATH


### PR DESCRIPTION
Pulling `googleapis` took a long time for these APIs, And adding this small change will make it a lot faster.