### PR TITLE
Use a consistent version of protoc across the docker containers used for cross-compilation

### DIFF
--- a/cross/Dockerfile.aarch64-unknown-linux-musl
+++ b/cross/Dockerfile.aarch64-unknown-linux-musl
@@ -2,5 +2,7 @@ FROM ghcr.io/cross-rs/aarch64-unknown-linux-musl:latest
 
 RUN apt-get update && \
     apt-get --assume-yes install \
-    protobuf-compiler \
-    libprotobuf-dev
+    curl
+
+ENV PB_REL="https://github.com/protocolbuffers/protobuf/releases"
+RUN curl -LO $PB_REL/download/v26.1/protoc-26.1-linux-x86_64.zip && unzip protoc-26.1-linux-x86_64.zip -d / && mv /include /bin/

--- a/cross/Dockerfile.armv7-unknown-linux-musleabihf
+++ b/cross/Dockerfile.armv7-unknown-linux-musleabihf
@@ -2,5 +2,7 @@ FROM ghcr.io/cross-rs/armv7-unknown-linux-musleabihf:latest
 
 RUN apt-get update && \
     apt-get --assume-yes install \
-    protobuf-compiler \
-    libprotobuf-dev
+    curl
+
+ENV PB_REL="https://github.com/protocolbuffers/protobuf/releases"
+RUN curl -LO $PB_REL/download/v26.1/protoc-26.1-linux-x86_64.zip && unzip protoc-26.1-linux-x86_64.zip -d / && mv /include /bin/

--- a/cross/Dockerfile.x86_64-unknown-linux-musl
+++ b/cross/Dockerfile.x86_64-unknown-linux-musl
@@ -2,5 +2,7 @@ FROM ghcr.io/cross-rs/x86_64-unknown-linux-musl:latest
 
 RUN apt-get update && \
     apt-get --assume-yes install \
-    protobuf-compiler \
-    libprotobuf-dev
+    curl
+
+ENV PB_REL="https://github.com/protocolbuffers/protobuf/releases"
+RUN curl -LO $PB_REL/download/v26.1/protoc-26.1-linux-x86_64.zip && unzip protoc-26.1-linux-x86_64.zip -d / && mv /include /bin/


### PR DESCRIPTION
Currently, each docker container that use used by cross may have a different version of protoc installed. I checked this by building each container and running `protoc --version`:

```
for f in Dockerfile.*; do docker build --no-cache -q -t test -f $f . && echo $f && docker run -it test protoc --version; done
```

getting the following output:
```
libprotoc 3.0.0
sha256:68cd72de533c2f63b6f1eff0a2f64d30d7eaaa1f60a81382fbe0614be772e719
Dockerfile.armv7-unknown-linux-musleabihf
libprotoc 3.6.1
sha256:89e4efc465f3553968e8c6ba1f326902e563cb82f5288a556b3409ce7f5ac352
Dockerfile.x86_64-unknown-linux-musl
libprotoc 3.6.1
```

So I propose that we download and install the specific version of protoc we want in each dockerfile. I've done so installing v26.1 which is the latest version and I have tested this in my own branch of chirpstack. Please let me know what you think.