### PR TITLE
Upgrade io.grpc dependencies in Java API to fix Netty compatibility issue

### DIFF
--- a/api/java/build.gradle.kts
+++ b/api/java/build.gradle.kts
@@ -21,10 +21,10 @@ buildscript {
 }
 
 dependencies {
-    api("io.grpc:grpc-protobuf:1.51.0")
-    api("io.grpc:grpc-api:1.51.0")
-    api("io.grpc:grpc-stub:1.51.0")
-    api("io.grpc:grpc-netty:1.51.0")
+    api("io.grpc:grpc-protobuf:1.59.1")
+    api("io.grpc:grpc-api:1.59.1")
+    api("io.grpc:grpc-stub:1.59.1")
+    api("io.grpc:grpc-netty:1.59.1")
     implementation("javax.annotation:javax.annotation-api:1.3.2")
 }
 


### PR DESCRIPTION
The Java API is unable to execute requests, for example listing the devices' list because of a `grpc-netty` compatibility issue.
See [](https://github.com/grpc/grpc-java/issues/10665) for more details.

Upgrading the dependency version solves the issue.