### PR TITLE
chirpstack_api::rust: make tonic pub

### DIFF
--- a/api/rust/src/lib.rs
+++ b/api/rust/src/lib.rs
@@ -1,4 +1,5 @@
 pub use prost;
+pub use tonic;
 #[cfg(feature = "api")]
 pub mod api;
 pub mod common;


### PR DESCRIPTION
Functions from the tonic generated client/host often return `tonic::Status`. This allows the library user to bring it into scope.