### PR TITLE
Build/archive package for both Postgres and SQLite

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,13 @@ jobs:
     needs: tests
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
+    strategy:
+      matrix:
+        database:
+          - postgres
+          - sqlite
+    env:
+      DATABASE: ${{ matrix.database }}
     steps:
       -
         name: Checkout

--- a/chirpstack/Cargo.toml
+++ b/chirpstack/Cargo.toml
@@ -240,6 +240,7 @@
     systemd-units = { enable = true }
 
   [package.metadata.deb.variants.postgres]
+    name = "chirpstack"
     suggests = "postgresql, mosquitto, redis"
     conflicts = "chirpstack-sqlite"
 
@@ -247,7 +248,7 @@
     default-features = false
     features = ["sqlite"]
     suggests = "sqlite3, mosquitto, redis"
-    conflicts = "chirpstack-postgres"
+    conflicts = "chirpstack"
 
   [package.metadata.generate-rpm]
     auto-req = "no"
@@ -272,11 +273,11 @@ chmod 640 /etc/chirpstack/*.toml
     ]
 
   [package.metadata.generate-rpm.variants.postgres]
-    name = "chirpstack-postgres"
+    name = "chirpstack"
   [package.metadata.generate-rpm.variants.postgres.conflicts]
     chirpstack-sqlite = "*"
 
   [package.metadata.generate-rpm.variants.sqlite]
     name = "chirpstack-sqlite"
   [package.metadata.generate-rpm.variants.sqlite.conflicts]
-    chirpstack-postgres = "*"
+    chirpstack = "*"

--- a/chirpstack/Cargo.toml
+++ b/chirpstack/Cargo.toml
@@ -234,7 +234,6 @@
       "/etc/chirpstack/region_us915_6.toml",
       "/etc/chirpstack/region_us915_7.toml",
     ]
-    provides = "chirpstack"
     suggests = "postgresql, mosquitto, redis"
     maintainer-scripts = "debian/"
     systemd-units = { enable = true }
@@ -247,7 +246,7 @@
   [package.metadata.deb.variants.sqlite]
     default-features = false
     features = ["sqlite"]
-    suggests = "sqlite3, mosquitto, redis"
+    suggests = "mosquitto, redis"
     conflicts = "chirpstack"
 
   [package.metadata.generate-rpm]

--- a/chirpstack/Cargo.toml
+++ b/chirpstack/Cargo.toml
@@ -234,9 +234,20 @@
       "/etc/chirpstack/region_us915_6.toml",
       "/etc/chirpstack/region_us915_7.toml",
     ]
+    provides = "chirpstack"
     suggests = "postgresql, mosquitto, redis"
     maintainer-scripts = "debian/"
     systemd-units = { enable = true }
+
+  [package.metadata.deb.variants.postgres]
+    suggests = "postgresql, mosquitto, redis"
+    conflicts = "chirpstack-sqlite"
+
+  [package.metadata.deb.variants.sqlite]
+    default-features = false
+    features = ["sqlite"]
+    suggests = "sqlite3, mosquitto, redis"
+    conflicts = "chirpstack-postgres"
 
   [package.metadata.generate-rpm]
     auto-req = "no"
@@ -259,3 +270,13 @@ chmod 640 /etc/chirpstack/*.toml
       { source = "configuration/*", dest = "/etc/chirpstack" },
       { source = "rpm/chirpstack.service", dest = "/lib/systemd/system/chirpstack.service" },
     ]
+
+  [package.metadata.generate-rpm.variants.postgres]
+    name = "chirpstack-postgres"
+  [package.metadata.generate-rpm.variants.postgres.conflicts]
+    chirpstack-sqlite = "*"
+
+  [package.metadata.generate-rpm.variants.sqlite]
+    name = "chirpstack-sqlite"
+  [package.metadata.generate-rpm.variants.sqlite.conflicts]
+    chirpstack-postgres = "*"

--- a/chirpstack/Makefile
+++ b/chirpstack/Makefile
@@ -17,13 +17,13 @@ dist:
 	cross build --target x86_64-unknown-linux-musl --release --no-default-features --features="$(DATABASE)"
 	cross build --target armv7-unknown-linux-musleabihf --release --no-default-features --features="$(DATABASE)"
 
-	cargo deb --target x86_64-unknown-linux-musl --no-build --no-strip
-	cargo deb --target armv7-unknown-linux-musleabihf --no-build --no-strip
-	cargo deb --target aarch64-unknown-linux-musl --no-build --no-strip
+	cargo deb --target x86_64-unknown-linux-musl --no-build --no-strip --variant="$(DATABASE)"
+	cargo deb --target armv7-unknown-linux-musleabihf --no-build --no-strip --variant="$(DATABASE)"
+	cargo deb --target aarch64-unknown-linux-musl --no-build --no-strip --variant="$(DATABASE)"
 
-	cargo generate-rpm --target x86_64-unknown-linux-musl --target-dir ../target
-	cargo generate-rpm --target armv7-unknown-linux-musleabihf --target-dir ../target
-	cargo generate-rpm --target aarch64-unknown-linux-musl --target-dir ../target
+	cargo generate-rpm --target x86_64-unknown-linux-musl --target-dir ../target --variant="$(DATABASE)"
+	cargo generate-rpm --target armv7-unknown-linux-musleabihf --target-dir ../target --variant="$(DATABASE)"
+	cargo generate-rpm --target aarch64-unknown-linux-musl --target-dir ../target --variant="$(DATABASE)"
 
 	mkdir -p ../dist
 
@@ -35,9 +35,9 @@ dist:
 	cp ../target/armv7-unknown-linux-musleabihf/generate-rpm/*.rpm ../dist
 	cp ../target/aarch64-unknown-linux-musl/generate-rpm/*.rpm ../dist
 
-	tar -czvf ../dist/chirpstack_$(PKG_VERSION)_amd64.tar.gz -C ../target/x86_64-unknown-linux-musl/release chirpstack
-	tar -czvf ../dist/chirpstack_$(PKG_VERSION)_armv7hf.tar.gz -C ../target/armv7-unknown-linux-musleabihf/release chirpstack
-	tar -czvf ../dist/chirpstack_$(PKG_VERSION)_arm64.tar.gz -C ../target/aarch64-unknown-linux-musl/release chirpstack
+	tar -czvf ../dist/chirpstack_$(PKG_VERSION)_$(DATABASE)_amd64.tar.gz -C ../target/x86_64-unknown-linux-musl/release chirpstack
+	tar -czvf ../dist/chirpstack_$(PKG_VERSION)_$(DATABASE)_armv7hf.tar.gz -C ../target/armv7-unknown-linux-musleabihf/release chirpstack
+	tar -czvf ../dist/chirpstack_$(PKG_VERSION)_$(DATABASE)_arm64.tar.gz -C ../target/aarch64-unknown-linux-musl/release chirpstack
 
 test:
 	cargo fmt --check


### PR DESCRIPTION
Add a CI matrix to build packages for both PostgreSQL and SQLite databases.
For each build, archive package with database name:
 - chirpstack-postgres
 - chirpstack-sqlite

For Debian and RPM, add:
 - Conflicts: chirpstack-sqlite / chirpstack-postgres respectively

For Debian only, add:
 - Provides: chirpstack