### PR TITLE
Do not return expired items in main scheduler loop.

### DIFF
--- a/api/grpc-web/package.json
+++ b/api/grpc-web/package.json
@@ -12,5 +12,6 @@
     "@types/google-protobuf": "^3.15.12",
     "google-protobuf": "^3.21.2",
     "grpc-web": "^1.5.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/chirpstack/src/storage/multicast.rs
+++ b/chirpstack/src/storage/multicast.rs
@@ -670,8 +670,10 @@ pub async fn get_schedulable_queue_items(limit: usize) -> Result<Vec<MulticastGr
                                     on g.gateway_id = qi.gateway_id
                                 where
                                     qi.scheduler_run_after <= $2
-                                    -- check that the gateway is online, except when the item already has expired
-                                    and ($2 - make_interval(secs => g.stats_interval_secs * 2) <= g.last_seen_at or expires_at <= $2)
+                                    -- check that the gateway is online
+                                    and (
+                                        $2 - make_interval(secs => g.stats_interval_secs * 2) <= g.last_seen_at
+                                    )
                                 order by
                                     qi.created_at
                                 limit $1

--- a/chirpstack/src/storage/multicast.rs
+++ b/chirpstack/src/storage/multicast.rs
@@ -675,7 +675,7 @@ pub async fn get_schedulable_queue_items(limit: usize) -> Result<Vec<MulticastGr
                                         $2 - make_interval(secs => g.stats_interval_secs * 2) <= g.last_seen_at
                                     )
                                     -- ignore expired messages
-                                    and not (qi.expires_at < $2)
+                                    and not (qi.expires_at is not null and qi.expires_at < $2)
                                 order by
                                     qi.created_at
                                 limit $1

--- a/chirpstack/src/storage/multicast.rs
+++ b/chirpstack/src/storage/multicast.rs
@@ -679,6 +679,7 @@ pub async fn get_schedulable_queue_items(limit: usize) -> Result<Vec<MulticastGr
                                 order by
                                     qi.created_at
                                 limit $1
+                                for update skip locked
                             )
                         returning *
                     "#

--- a/chirpstack/src/storage/multicast.rs
+++ b/chirpstack/src/storage/multicast.rs
@@ -674,6 +674,8 @@ pub async fn get_schedulable_queue_items(limit: usize) -> Result<Vec<MulticastGr
                                     and (
                                         $2 - make_interval(secs => g.stats_interval_secs * 2) <= g.last_seen_at
                                     )
+                                    -- ignore expired messages
+                                    and not (qi.expires_at < $2)
                                 order by
                                     qi.created_at
                                 limit $1


### PR DESCRIPTION
We believe this to be creating a large amount of load on the scheduler as it has to go and delete the expired messages one by one.

Instead we will set up a separate process to periodically clear out the expired messages.