### PR TITLE
Update amqp integration to allow configuring the exchange in Chirpstack.toml

### DIFF
--- a/chirpstack/src/config.rs
+++ b/chirpstack/src/config.rs
@@ -352,6 +352,7 @@ pub struct AmqpIntegration {
     pub url: String,
     pub json: bool,
     pub event_routing_key: String,
+    pub exchange: String,
 }
 
 impl Default for AmqpIntegration {
@@ -361,6 +362,7 @@ impl Default for AmqpIntegration {
             json: true,
             event_routing_key: "application.{{application_id}}.device.{{dev_eui}}.event.{{event}}"
                 .to_string(),
+            exchange: "amq.topic".to_string(),
         }
     }
 }

--- a/chirpstack/src/integration/amqp.rs
+++ b/chirpstack/src/integration/amqp.rs
@@ -27,6 +27,7 @@ pub struct Integration<'a> {
     templates: Handlebars<'a>,
     json: bool,
     url: String,
+    exchange: String,
 }
 
 #[derive(Serialize)]
@@ -49,6 +50,7 @@ impl<'a> Integration<'a> {
             templates,
             url: conf.url.clone(),
             json: conf.json,
+            exchange: conf.exchange.clone(),
         };
         i.connect().await?;
 
@@ -90,7 +92,7 @@ impl<'a> Integration<'a> {
                 .as_ref()
                 .unwrap()
                 .basic_publish(
-                    "amq.topic",
+                    &self.exchange,
                     &routing_key,
                     BasicPublishOptions::default(),
                     b,


### PR DESCRIPTION
Currently for the amqp integration Chirpstack has the topic "amq.topic" hardcoded into the publish function. 

This change would allow configuring the amqp exchange in the [integration.amqp] section of your chirpstack.toml, as a new config called 'exchange'. If 'exchange' is not configured in that section the default "amq.topic" will be used. 

The Chirpstack configuration page (https://www.chirpstack.io/docs/chirpstack/configuration.html) should also be updated as follows to show the additional config:

```
  # AMQP / RabbitMQ integration configuration.
  [integration.amqp]

    # Server URL.
    #
    # See for a specification of all the possible options:
    # https://www.rabbitmq.com/uri-spec.html
    url="amqp://guest:guest@localhost:5672"

    # Event routing key.
    #
    # This is the event routing-key template used when publishing device
    # events. Messages will be published to the "amq.topic" exchange by default.
    event_routing_key="application.{{application_id}}.device.{{dev_eui}}.event.{{event}}"

    # Use JSON encoding instead of Protobuf (binary).
    json=true

   # The AMQP exchange the events are posted to.
   exchange = "amq.topic"
```

And the amqp integration section of the documentation (https://www.chirpstack.io/docs/chirpstack/integrations/amqp.html) should be updated as well:

```
# AMQP / RabbitMQ integration configuration.
[integration.amqp]
  url="amqp://guest:guest@localhost:5672"
  event_routing_key="application.{{application_id}}.device.{{dev_eui}}.event.{{event}}"
  json=true
 exchange = "amq.topic"
```