### PR TITLE
Ensure the nix dev shell has jq

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -23,6 +23,7 @@ pkgs.mkShell {
     pkgs.cargo-cross            # cross-compiling
     pkgs.cargo-deb              # deb packaging
     pkgs.diesel-cli             # diesel cli
+    pkgs.jq                     # json query cli tool
   ];
   LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
   BINDGEN_EXTRA_CLANG_ARGS = "-I${pkgs.llvmPackages.libclang.lib}/lib/clang/${pkgs.llvmPackages.libclang.version}/include";


### PR DESCRIPTION
chirpstack/Makefile uses jq to populate the PKG_VERSION variable.