### PR TITLE
adr: plugin_skeleton: Use the result in the comment

### DIFF
--- a/examples/adr_plugins/plugin_skeleton.js
+++ b/examples/adr_plugins/plugin_skeleton.js
@@ -44,7 +44,7 @@ export function id() {
 //
 // This function must return an object, example:
 // {
-//  dr: 2,
+//  dr: 5,
 //  txPowerIndex: 1,
 //  nbTrans: 1
 // }


### PR DESCRIPTION
The comment of the `plugin_skeleton.js` does not happen to be what the algorithm returns for the input example. This might confuse users.

This commit fixes that.