### PR TITLE
Added dev_eui query param to list multicast groups api

### DIFF
--- a/api/proto/api/multicast_group.proto
+++ b/api/proto/api/multicast_group.proto
@@ -248,6 +248,9 @@ message ListMulticastGroupsRequest {
 
     // Application ID to list the multicast groups for.
     string application_id = 4;
+
+    // Device EUI (HEX encoded).
+    string dev_eui = 5;
 }
 
 message ListMulticastGroupsResponse {

--- a/chirpstack/src/api/multicast.rs
+++ b/chirpstack/src/api/multicast.rs
@@ -203,6 +203,7 @@ impl MulticastGroupService for MulticastGroup {
     ) -> Result<Response<api::ListMulticastGroupsResponse>, Status> {
         let req = request.get_ref();
         let app_id = Uuid::from_str(&req.application_id).map_err(|e| e.status())?;
+        let dev_eui = EUI64::from_str(&req.dev_eui).map_err(|e| e.status())?;
 
         self.validator
             .validate(
@@ -213,6 +214,7 @@ impl MulticastGroupService for MulticastGroup {
 
         let filters = multicast::Filters {
             application_id: Some(app_id),
+            dev_eui: Some(dev_eui),
             search: if req.search.is_empty() {
                 None
             } else {

--- a/chirpstack/src/storage/multicast.rs
+++ b/chirpstack/src/storage/multicast.rs
@@ -84,6 +84,7 @@ pub struct MulticastGroupListItem {
 pub struct Filters {
     pub application_id: Option<Uuid>,
     pub search: Option<String>,
+    pub dev_eui: Option<EUI64>,
 }
 
 #[derive(Clone, Queryable, QueryableByName, Insertable, AsChangeset, Debug, PartialEq, Eq)]
@@ -197,6 +198,16 @@ pub async fn get_count(filters: &Filters) -> Result<i64, Error> {
         q = q.filter(multicast_group::dsl::application_id.eq(fields::Uuid::from(application_id)));
     }
 
+    if let Some(dev_eui) = &filters.dev_eui {
+        q = q.filter(
+            multicast_group::dsl::id.eq_any(
+                multicast_group_device::dsl::multicast_group_device
+                    .select(multicast_group_device::dsl::multicast_group_id)
+                    .filter(multicast_group_device::dsl::dev_eui.eq(dev_eui)),
+            ),
+        );
+    }
+
     if let Some(search) = &filters.search {
         #[cfg(feature = "postgres")]
         {
@@ -231,6 +242,16 @@ pub async fn list(
 
     if let Some(application_id) = &filters.application_id {
         q = q.filter(multicast_group::dsl::application_id.eq(fields::Uuid::from(application_id)));
+    }
+
+    if let Some(dev_eui) = &filters.dev_eui {
+        q = q.filter(
+            multicast_group::dsl::id.eq_any(
+                multicast_group_device::dsl::multicast_group_device
+                    .select(multicast_group_device::dsl::multicast_group_id)
+                    .filter(multicast_group_device::dsl::dev_eui.eq(dev_eui)),
+            ),
+        );
     }
 
     if let Some(search) = &filters.search {


### PR DESCRIPTION
## Summary

This PR adds support for filtering multicast groups by an associated device's DevEUI in the ChirpStack v4 API.

### Changes
- **API (`ListMulticastGroupsRequest`)**
  - Added an optional `device_dev_eui` field to allow filtering by device association.

- **Data Layer (`Filters` struct)**
  - Introduced a new `device_dev_eui: Option<EUI64>` field to store the binary representation of the DevEUI.

- **Query Logic**
  - Updated `list` and `get_count` functions to:
    - Apply a `WHERE id IN (SELECT multicast_group_id FROM multicast_group_device WHERE dev_eui = ?)` subselect when `device_dev_eui` is provided.

### Motivation
Previously, there was no direct way to retrieve multicast groups associated with a specific device via the API.  
This change improves usability by allowing a single API call to return only the multicast groups linked to the provided DevEUI.