### PR TITLE
config: add option to flatten_json

### DIFF
--- a/chirpstack/configuration/chirpstack.toml
+++ b/chirpstack/configuration/chirpstack.toml
@@ -6,6 +6,7 @@
   # Options are: trace, debug, info, warn error.
   level = "info"
 
+
 # PostgreSQL configuration.
 [postgresql]
 

--- a/chirpstack/configuration/chirpstack.toml
+++ b/chirpstack/configuration/chirpstack.toml
@@ -5,9 +5,6 @@
   #
   # Options are: trace, debug, info, warn error.
   level = "info"
-  json = false
-  flatten_json = false
-
 
 # PostgreSQL configuration.
 [postgresql]

--- a/chirpstack/configuration/chirpstack.toml
+++ b/chirpstack/configuration/chirpstack.toml
@@ -5,6 +5,8 @@
   #
   # Options are: trace, debug, info, warn error.
   level = "info"
+  json = false
+  flatten_json = false
 
 
 # PostgreSQL configuration.

--- a/chirpstack/src/cmd/configfile.rs
+++ b/chirpstack/src/cmd/configfile.rs
@@ -19,6 +19,9 @@ pub fn run() {
 
   # Log as JSON.
   json={{ logging.json }}
+  
+  # Flatten JSON logs
+  json={{ logging.flatten_json }}
 
 
 # PostgreSQL configuration.

--- a/chirpstack/src/config.rs
+++ b/chirpstack/src/config.rs
@@ -39,6 +39,7 @@ pub struct Configuration {
 pub struct Logging {
     pub level: String,
     pub json: bool,
+    pub flatten_json: bool,
 }
 
 impl Default for Logging {
@@ -46,6 +47,7 @@ impl Default for Logging {
         Logging {
             level: "info".into(),
             json: false,
+            flatten_json: false,
         }
     }
 }

--- a/chirpstack/src/main.rs
+++ b/chirpstack/src/main.rs
@@ -100,12 +100,12 @@ async fn main() -> Result<()> {
         ("backend", Level::from_str(&conf.logging.level).unwrap()),
         ("lrwn", Level::from_str(&conf.logging.level).unwrap()),
     ]);
-    
     if conf.logging.json {
         tracing_subscriber::registry()
-            .with(tracing_subscriber::fmt::layer()
-                .json()
-                .flatten_event(conf.logging.flatten_json)
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .json()
+                    .flatten_event(conf.logging.flatten_json),
             )
             .with(filter)
             .init();

--- a/chirpstack/src/main.rs
+++ b/chirpstack/src/main.rs
@@ -100,10 +100,13 @@ async fn main() -> Result<()> {
         ("backend", Level::from_str(&conf.logging.level).unwrap()),
         ("lrwn", Level::from_str(&conf.logging.level).unwrap()),
     ]);
-
+    
     if conf.logging.json {
         tracing_subscriber::registry()
-            .with(tracing_subscriber::fmt::layer().json())
+            .with(tracing_subscriber::fmt::layer()
+                .json()
+                .flatten_event(conf.logging.flatten_json)
+            )
             .with(filter)
             .init();
     } else {


### PR DESCRIPTION
# What this does 

Add an option to flatten the JSON Log fields (so they show up at the top level)

## Example

Currently, the [tracing](https://github.com/tokio-rs/tracing) crate defaults to nested logs in json format (inside `fields`)

```json
{ "timestamp": "2025-09...", "level": "INFO", "fields": { "message": "User logged in" }  }
```

With this flag enabled the message is flattened

```toml
[logging]
level = "info"
json = true
flatten_json = true # <===
```

```json
{ "timestamp": "2025-09...", "level": "INFO",  "message": "User logged in" }
```

## Details

We have a deployment of ChirpStack running on an internal PaaS. 

However the logging schema is fixed and requires the main `message` field to be at top level of the JSON document
