### PR TITLE
Add configurable PostgreSQL connection recycling method

### DIFF
--- a/chirpstack/configuration/chirpstack.toml
+++ b/chirpstack/configuration/chirpstack.toml
@@ -33,6 +33,18 @@
   # pool (0 = equal to max_open_connections).
   min_idle_connections = 0
 
+  # Connection recycling method.
+  #
+  # This controls how connections are validated when returned to the connection pool.
+  # Options:
+  #  * verified - Run a validation query (SELECT 1) when recycling connections (safer, slightly slower)
+  #  * fast - Skip validation query when recycling connections (faster, but may return stale connections)
+  #
+  # The 'verified' method is recommended for production use to ensure connection health.
+  # Use 'fast' when using an external connection pooler (PgBouncer, AWS RDS Proxy,
+  # GCP Cloud SQL Connection Pooling) that already handles connection validation.
+  connection_recycling_method = "verified"
+
 
 # Redis configuration.
 [redis]

--- a/chirpstack/src/config.rs
+++ b/chirpstack/src/config.rs
@@ -58,6 +58,7 @@ pub struct Postgresql {
     pub dsn: String,
     pub max_open_connections: u32,
     pub ca_cert: String,
+    pub connection_recycling_method: String,
 }
 
 impl Default for Postgresql {
@@ -66,6 +67,7 @@ impl Default for Postgresql {
             dsn: "postgresql://chirpstack:chirpstack@localhost/chirpstack?sslmode=disable".into(),
             max_open_connections: 10,
             ca_cert: "".into(),
+            connection_recycling_method: "verified".into(),
         }
     }
 }
@@ -885,4 +887,18 @@ pub fn get_required_snr_for_sf(sf: u8) -> Result<f32> {
             return Err(anyhow!("Unknown sf {} for get_required_snr_for_sf", sf));
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_postgresql_connection_recycling_method_default() {
+        let conf = Postgresql::default();
+        assert_eq!(
+            conf.connection_recycling_method, "verified",
+            "Default connection_recycling_method should be 'verified' for backwards compatibility"
+        );
+    }
 }


### PR DESCRIPTION
High Latency in `pool.get()` Due to Default `RecyclingMethod::Verified`

## Summary

When using ChirpStack with a PostgreSQL database in a different geographic region (e.g., EU client connecting to US database), every call to `pool.get().await` incurs significant latency (~110ms for EU→US) due to an implicit `SELECT 1` validation query executed on every connection retrieval from the pool.

## Example Environment

- **ChirpStack Version**: 4.15.0
- **Database**: GCP Cloud SQL Enterprise Plus PostgreSQL with [Managed Connection Pooling](https://cloud.google.com/sql/docs/postgres/managed-connection-pooling) enabled
- **Connection Method**: Cloud SQL Auth Proxy
- **Client Location**: EU
- **Database Location**: US
- **Observed Connection Latency**:
  - US client → US database: ~24ms
  - EU client → US database: ~110ms (round-trip latency)

### Note on Cloud SQL Enterprise Plus Managed Connection Pooling

Cloud SQL Enterprise Plus provides [Managed Connection Pooling](https://cloud.google.com/sql/docs/postgres/managed-connection-pooling), an enterprise-level built-in connection pooler (similar to PgBouncer) that sits between the application and PostgreSQL. This managed service handles connection pooling at the database layer, and as an enterprise-level feature, we can reasonably assume it validates and manages its internal pool of database connections.

**However**, this does not eliminate the application-side connection validation. The architecture involves two separate connection pools:

1. **Application Pool** (ChirpStack's `deadpool`): Between the application and Cloud SQL Pooler
2. **Database Pool** (Cloud SQL Managed Connection Pooling): Between the pooler and PostgreSQL

The `SELECT 1` validation query in question is executed by the **application's connection pool** (via diesel-async's `RecyclingMethod::Verified`) when checking out connections to the Cloud SQL pooler. This occurs on every `pool.get()` call, incurring the full EU→US round-trip latency (~110ms), even though the Cloud SQL pooler manages its own downstream connections to PostgreSQL efficiently.

In essence, the application is validating connections to the pooler, not to the database itself, but still paying the geographic latency penalty.

## Root Cause

ChirpStack uses `diesel-async` with `deadpool` for connection pooling. The `diesel-async` library defines a `RecyclingMethod` enum with **`Verified` as the default** (not `Fast`):

**File**: [`diesel-async/src/pooled_connection/mod.rs` (lines 51-71)](https://github.com/weiznich/diesel_async/blob/main/src/pooled_connection/mod.rs#L51-L71)

```rust
#[derive(Default)]
pub enum RecyclingMethod<C> {
    /// Only check for open transactions when recycling existing connections
    Fast,
    /// In addition to checking for open transactions a test query is executed
    #[default]      // ← THIS MAKES Verified THE DEFAULT!
    Verified,       // ← Executes SELECT 1 on every pool.get()
    CustomQuery(Cow<'static, str>),
    CustomFunction(Box<RecycleCheckCallback<C>>),
}
```

### Code Path on Every `pool.get()` Call

1. **Deadpool calls the `recycle()` method**

   **File**: [`diesel-async/src/pooled_connection/deadpool.rs` (lines 91-105)](https://github.com/weiznich/diesel_async/blob/main/src/pooled_connection/deadpool.rs#L91-L105)

   ```rust
   async fn recycle(
       &self,
       obj: &mut Self::Type,
       _: &deadpool::managed::Metrics,
   ) -> deadpool::managed::RecycleResult<Self::Error> {
       if std::thread::panicking() || obj.is_broken() {
           return Err(deadpool::managed::RecycleError::Message(
               "Broken connection".into(),
           ));
       }
       obj.ping(&self.manager_config.recycling_method)  // ← Calls ping()
           .await
           .map_err(super::PoolError::QueryError)?;
       Ok(())
   }
   ```

2. **The `ping()` method executes based on `RecyclingMethod`**

   **File**: [`diesel-async/src/pooled_connection/mod.rs` (lines 170-199)](https://github.com/weiznich/diesel_async/blob/main/src/pooled_connection/mod.rs#L170-L199)

   ```rust
   fn ping(
       &mut self,
       config: &RecyclingMethod<Self>,
   ) -> impl Future<Output = diesel::QueryResult<()>> + Send {
       use crate::run_query_dsl::RunQueryDsl;
       use diesel::IntoSql;

       async move {
           match config {
               RecyclingMethod::Fast => Ok(()),           // No database query
               RecyclingMethod::Verified => {             // ← DEFAULT BEHAVIOR
                   diesel::select(1_i32.into_sql::<diesel::sql_types::Integer>())
                       .execute(self)                     // ← EXECUTES "SELECT 1"
                       .await
                       .map(|_| ())
               }
               RecyclingMethod::CustomQuery(query) => diesel::sql_query(query.as_ref())
                   .execute(self)
                   .await
                   .map(|_| ()),
               RecyclingMethod::CustomFunction(c) => c(self).await,
           }
       }
   }
   ```

3. **ChirpStack does not explicitly set `RecyclingMethod`**

   **File**: [`chirpstack/chirpstack/src/storage/postgres.rs` (lines 34-45)](https://github.com/chirpstack/chirpstack/blob/master/chirpstack/src/storage/postgres.rs#L34-L45)

   ```rust
   pub fn setup(conf: &config::Postgresql) -> Result<()> {
       info!("Setting up PostgreSQL connection pool");
       let mut config = ManagerConfig::default();
       config.custom_setup = Box::new(pg_establish_connection);
       // ← recycling_method is not set, so defaults to RecyclingMethod::Verified
       let mgr = AsyncDieselConnectionManager::<AsyncPgConnection>::new_with_config(&conf.dsn, config);
       let pool = DeadpoolPool::builder(mgr)
           .max_size(conf.max_open_connections as usize)
           .build()?;
       set_async_db_pool(pool);

       Ok(())
   }
   ```

## Impact

- **Every** `pool.get()` call executes `SELECT 1` against the database
- This requires a full network round-trip to the database server
- For geographically distributed deployments (e.g., EU → US), this adds ~110ms latency
- The latency is incurred even when retrieving an **existing connection** from the pool (not just when creating new connections)
- This affects all database operations throughout the application

## Solution

Add a new configuration setting in `connection_recycling_method` in the `[postgresql]` section of `chirpstack.toml`.  Valid values are:

* verified - (default) Run a validation query (SELECT 1) when recycling connections (safer, slightly slower)
* fast - Skip validation query when recycling connections (faster, but may return stale connections)

 The 'verified' method is recommended for production use to ensure connection health.
 
Use 'fast' when using an external connection pooler (PgBouncer, AWS RDS Proxy, GCP Cloud SQL Connection Pooling) that already handles connection validation.

This is the result (blue line), based on ChirpStack Prometheus metrics. 

<img width="1480" height="563" alt="Screenshot from 2025-11-26 20-31-25" src="https://github.com/user-attachments/assets/7f59fb42-e500-4108-b271-a638314930a5" />


* Note: The Redis connection time was dropped by using a proxy, as `deadpool-redis` does not have the ability to skip the validation on every connection retrieval.