### PR TITLE
Fix ModuleNotFoundError in Python API: Remove obsolete device profile template imports from api/__init__.py

### DIFF
--- a/api/python/src/chirpstack_api/api/__init__.py
+++ b/api/python/src/chirpstack_api/api/__init__.py
@@ -4,8 +4,6 @@ from .device_pb2 import *
 from .device_pb2_grpc import *
 from .device_profile_pb2 import *
 from .device_profile_pb2_grpc import *
-from .device_profile_template_pb2 import *
-from .device_profile_template_pb2_grpc import *
 from .gateway_pb2 import *
 from .gateway_pb2_grpc import *
 from .internal_pb2 import *


### PR DESCRIPTION
Hello, my understanding is that these two imports are now obsolete thus causing ModuleNotFoundError errors with the python API package built from current source. 

https://github.com/chirpstack/chirpstack/blob/2156d0661d35d068d559c9b94db919c4bb43b695/api/python/src/chirpstack_api/api/__init__.py#L7-L8

Let me know if there are other files affected.

Best,
Alessandro