### PR TITLE
fix: OIDC/oAuth2 user menu crash by initializing menu items correctly

### DIFF
--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -83,18 +83,16 @@ function Header({ user }: { user: User }) {
   const oidcEnabled = settings!.getOpenidConnect()!.getEnabled();
   const oAuth2Enabled = settings!.getOauth2()!.getEnabled();
 
-  let menu: MenuProps = {};
+  let menu: MenuProps = { items: [] };
 
   if (!(oidcEnabled || oAuth2Enabled)) {
-    menu.items = [
-      {
-        key: "change-pw",
-        label: <Link to={`/users/${user.getId()}/password`}>Change password</Link>,
-      },
-    ];
+    menu.items!.push({
+      key: "change-pw",
+      label: <Link to={`/users/${user.getId()}/password`}>Change password</Link>,
+    });
   }
 
-  menu.items?.push({
+  menu.items!.push({
     key: "logout",
     label: "Logout",
     onClick: onLogout,


### PR DESCRIPTION
In case of OIDC / oAuth2 the menu.items array will never be initialized, causing the UI to crash on clicking the User Dropdown.

Fixed by initializing the items array outside of the if statement.