### PR TITLE
add GCP Workload Identity Federation  support for PubSub Integration

### DIFF
--- a/chirpstack/src/integration/gcp_pub_sub.rs
+++ b/chirpstack/src/integration/gcp_pub_sub.rs
@@ -9,7 +9,7 @@ use gcp_auth::{CustomServiceAccount, TokenProvider};
 use prost::Message;
 use reqwest::Client;
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tracing::{info, trace};
 
 use super::Integration as IntegrationTrait;
@@ -30,11 +30,161 @@ fn get_client() -> Client {
         .clone()
 }
 
+#[derive(Deserialize)]
+struct CredentialFile {
+    #[serde(rename = "type")]
+    credential_type: String,
+}
+
+#[derive(Deserialize)]
+struct ExternalAccountConfig {
+    audience: String,
+    subject_token_type: String,
+    token_url: String,
+    credential_source: CredentialSource,
+    service_account_impersonation_url: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct CredentialSource {
+    file: String,
+}
+
+#[derive(Deserialize)]
+struct StsTokenResponse {
+    access_token: String,
+}
+
+#[derive(Serialize)]
+struct GenerateAccessTokenRequest {
+    scope: Vec<String>,
+    lifetime: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GenerateAccessTokenResponse {
+    access_token: String,
+}
+
+enum GcpAuthProvider {
+    ServiceAccount(CustomServiceAccount),
+    ExternalAccount(ExternalAccountProvider),
+}
+
+struct ExternalAccountProvider {
+    audience: String,
+    subject_token_type: String,
+    token_url: String,
+    credential_source_file: String,
+    service_account_impersonation_url: Option<String>,
+}
+
+impl ExternalAccountProvider {
+    fn from_json(json: &str) -> Result<Self> {
+        let config: ExternalAccountConfig =
+            serde_json::from_str(json).context("Parse external account credentials")?;
+
+        if !config.token_url.starts_with("https://sts.googleapis.com/") {
+            return Err(anyhow!("Invalid token_url: must be an STS endpoint"));
+        }
+        if let Some(ref url) = config.service_account_impersonation_url {
+            if !url.starts_with("https://iamcredentials.googleapis.com/") {
+                return Err(anyhow!(
+                    "Invalid service_account_impersonation_url: must be an IAM credentials endpoint"
+                ));
+            }
+        }
+
+        Ok(Self {
+            audience: config.audience,
+            subject_token_type: config.subject_token_type,
+            token_url: config.token_url,
+            credential_source_file: config.credential_source.file,
+            service_account_impersonation_url: config.service_account_impersonation_url,
+        })
+    }
+
+    async fn token(&self, scopes: &[&str]) -> Result<String> {
+        let subject_token = tokio::fs::read_to_string(&self.credential_source_file)
+            .await
+            .context("Read subject token file")?;
+
+        // When using service account impersonation, the STS token needs
+        // cloud-platform scope to be able to call generateAccessToken.
+        // The target scopes are then requested in the impersonation call.
+        let sts_scope = if self.service_account_impersonation_url.is_some() {
+            "https://www.googleapis.com/auth/cloud-platform".to_string()
+        } else {
+            scopes.join(" ")
+        };
+
+        let sts_resp: StsTokenResponse = get_client()
+            .post(&self.token_url)
+            .form(&[
+                (
+                    "grant_type",
+                    "urn:ietf:params:oauth:grant-type:token-exchange",
+                ),
+                ("audience", &self.audience),
+                ("subject_token_type", &self.subject_token_type),
+                (
+                    "requested_token_type",
+                    "urn:ietf:params:oauth:token-type:access_token",
+                ),
+                ("subject_token", subject_token.trim()),
+                ("scope", &sts_scope),
+            ])
+            .send()
+            .await
+            .context("STS token exchange request")?
+            .error_for_status()
+            .context("STS token exchange")?
+            .json()
+            .await
+            .context("Parse STS token response")?;
+
+        if let Some(ref impersonation_url) = self.service_account_impersonation_url {
+            let resp: GenerateAccessTokenResponse = get_client()
+                .post(impersonation_url)
+                .header(AUTHORIZATION, format!("Bearer {}", sts_resp.access_token))
+                .json(&GenerateAccessTokenRequest {
+                    scope: scopes.iter().map(|s| s.to_string()).collect(),
+                    lifetime: "3600s".to_string(),
+                })
+                .send()
+                .await
+                .context("Service account impersonation request")?
+                .error_for_status()
+                .context("Service account impersonation")?
+                .json()
+                .await
+                .context("Parse impersonation response")?;
+
+            return Ok(resp.access_token);
+        }
+
+        Ok(sts_resp.access_token)
+    }
+}
+
+impl GcpAuthProvider {
+    async fn token(&self, scopes: &[&str]) -> Result<String> {
+        match self {
+            GcpAuthProvider::ServiceAccount(sa) => {
+                let token = sa.token(scopes).await.context("Get GCP bearer token")?;
+                Ok(token.as_str().to_string())
+            }
+            GcpAuthProvider::ExternalAccount(ea) => ea.token(scopes).await,
+        }
+    }
+}
+
 pub struct Integration {
     json: bool,
     project_id: String,
     topic_name: String,
-    service_account: gcp_auth::CustomServiceAccount,
+    auth_provider: GcpAuthProvider,
 }
 
 #[derive(Serialize)]
@@ -58,7 +208,35 @@ struct PubSubMessageAttributes {
 impl Integration {
     pub async fn new(conf: &GcpPubSubConfiguration) -> Result<Integration> {
         trace!("Initializing GCP Pub-Sub integration");
-        let service_account = CustomServiceAccount::from_json(&conf.credentials_file)?;
+
+        let cred_file: CredentialFile = serde_json::from_str(&conf.credentials_file)
+            .context("Parse credentials file")?;
+
+        let auth_provider = match cred_file.credential_type.as_str() {
+            "service_account" => match CustomServiceAccount::from_json(&conf.credentials_file) {
+                Ok(sa) => GcpAuthProvider::ServiceAccount(sa),
+                Err(service_err) => {
+                    // Some deployments provide external-account credentials with an incorrect
+                    // `type` field. Try external-account parsing before returning an error.
+                    if let Ok(ea) = ExternalAccountProvider::from_json(&conf.credentials_file) {
+                        info!(
+                            "Detected external-account credential format while type=service_account; using external-account provider"
+                        );
+                        GcpAuthProvider::ExternalAccount(ea)
+                    } else {
+                        return Err(anyhow!(
+                            "Invalid service_account credentials: {}. If you are using Workload Identity Federation, set `type` to `external_account`",
+                            service_err
+                        ));
+                    }
+                }
+            },
+            "external_account" => {
+                let ea = ExternalAccountProvider::from_json(&conf.credentials_file)?;
+                GcpAuthProvider::ExternalAccount(ea)
+            }
+            other => return Err(anyhow!("Unsupported credential type: {}", other)),
+        };
 
         Ok(Integration {
             json: match Encoding::try_from(conf.encoding)
@@ -69,7 +247,7 @@ impl Integration {
             },
             project_id: conf.project_id.clone(),
             topic_name: conf.topic_name.clone(),
-            service_account,
+            auth_provider,
         })
     }
 
@@ -100,16 +278,15 @@ impl Integration {
         let pl = serde_json::to_string(&pl)?;
 
         let token = self
-            .service_account
+            .auth_provider
             .token(&["https://www.googleapis.com/auth/pubsub"])
-            .await
-            .context("Get GCP bearer token")?;
+            .await?;
 
         let mut headers = HeaderMap::new();
         headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
         headers.insert(
             AUTHORIZATION,
-            format!("Bearer {}", token.as_str()).parse().unwrap(),
+            format!("Bearer {}", token).parse().unwrap(),
         );
 
         let res = get_client()


### PR DESCRIPTION
Hello @brocaar ,

this patch allows the use of GCP Workload Identity Federation (WIF) in addition to static service account key files.

To use GCP WIF, configure the Chirpstack App container using a GCP external account and get the federation token mounted in the container, in this example there /var/run/secrets/tokens/wif-token. 

Then configure the integration in the UI like this:

```
{
  "type": "external_account",
  "audience": "//iam.googleapis.com/projects/<PROJECT_NUMBER>/locations/global/workloadIdentityPools/<WIF-POOL>/providers/<WIF-PROVIDER>",
  "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
  "token_url": "https://sts.googleapis.com/v1/token",
  "credential_source": {
    "file": "/var/run/secrets/tokens/wif-token",
    "format": {
      "type": "text"
    }
  },
  "service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/<SERVICE_ACCOUNT_EMAIL>:generateAccessToken"
}
```

