### PR TITLE
postgresql: Support non-TLS connections

### DIFF
--- a/chirpstack/configuration/chirpstack.toml
+++ b/chirpstack/configuration/chirpstack.toml
@@ -13,6 +13,9 @@
   # PostgreSQL DSN.
   #
   # Format example: postgres://<USERNAME>:<PASSWORD>@<HOSTNAME>/<DATABASE>?sslmode=<SSLMODE>.
+  # Unix socket example:
+  #   postgresql:///chirpstack?user=chirpstack&host=/var/run/postgresql&sslmode=disable
+  # When sslmode=disable, ChirpStack connects without TLS.
   #
   # SSL mode options:
   #  * disable - no SSL

--- a/chirpstack/src/helpers/mod.rs
+++ b/chirpstack/src/helpers/mod.rs
@@ -1,3 +1,4 @@
 pub mod errors;
+pub mod postgresql;
 pub mod tls;
 pub mod tls22; // rustls 0.22

--- a/chirpstack/src/helpers/postgresql.rs
+++ b/chirpstack/src/helpers/postgresql.rs
@@ -1,0 +1,44 @@
+use std::str::FromStr;
+
+use diesel::{ConnectionError, ConnectionResult};
+use diesel_async::AsyncPgConnection;
+use tokio_postgres::NoTls;
+use tokio_postgres::config::SslMode;
+use tracing::error;
+
+use crate::helpers::tls::get_root_certs;
+
+fn bad_connection<E: std::fmt::Display>(err: E) -> ConnectionError {
+    ConnectionError::BadConnection(err.to_string())
+}
+
+pub async fn establish_connection(config: &str, ca_cert: Option<String>) -> ConnectionResult<AsyncPgConnection> {
+    let parsed = tokio_postgres::Config::from_str(config).map_err(bad_connection)?;
+    let ssl_mode = parsed.get_ssl_mode();
+
+    let (client, conn) = match ssl_mode {
+        SslMode::Disable => tokio_postgres::connect(config, NoTls)
+            .await
+            .map_err(bad_connection)?,
+        _ => {
+            let root_certs =
+                get_root_certs(ca_cert.filter(|v| !v.is_empty())).map_err(bad_connection)?;
+            let rustls_config = rustls::ClientConfig::builder()
+                .with_root_certificates(root_certs)
+                .with_no_client_auth();
+            let tls = tokio_postgres_rustls::MakeRustlsConnect::new(rustls_config);
+
+            tokio_postgres::connect(config, tls)
+                .await
+                .map_err(bad_connection)?
+        }
+    };
+
+    tokio::spawn(async move {
+        if let Err(e) = conn.await {
+            error!(error = %e, "PostgreSQL connection error");
+        }
+    });
+
+    AsyncPgConnection::try_from(client).await
+}

--- a/chirpstack/src/helpers/postgresql.rs
+++ b/chirpstack/src/helpers/postgresql.rs
@@ -16,10 +16,20 @@ pub async fn establish_connection(config: &str, ca_cert: Option<String>) -> Conn
     let parsed = tokio_postgres::Config::from_str(config).map_err(bad_connection)?;
     let ssl_mode = parsed.get_ssl_mode();
 
-    let (client, conn) = match ssl_mode {
-        SslMode::Disable => tokio_postgres::connect(config, NoTls)
-            .await
-            .map_err(bad_connection)?,
+    match ssl_mode {
+        SslMode::Disable => {
+            let (client, conn) = tokio_postgres::connect(config, NoTls)
+                .await
+                .map_err(bad_connection)?;
+
+            tokio::spawn(async move {
+                if let Err(e) = conn.await {
+                    error!(error = %e, "PostgreSQL connection error");
+                }
+            });
+
+            AsyncPgConnection::try_from(client).await
+        }
         _ => {
             let root_certs =
                 get_root_certs(ca_cert.filter(|v| !v.is_empty())).map_err(bad_connection)?;
@@ -27,18 +37,17 @@ pub async fn establish_connection(config: &str, ca_cert: Option<String>) -> Conn
                 .with_root_certificates(root_certs)
                 .with_no_client_auth();
             let tls = tokio_postgres_rustls::MakeRustlsConnect::new(rustls_config);
-
-            tokio_postgres::connect(config, tls)
+            let (client, conn) = tokio_postgres::connect(config, tls)
                 .await
-                .map_err(bad_connection)?
-        }
-    };
+                .map_err(bad_connection)?;
 
-    tokio::spawn(async move {
-        if let Err(e) = conn.await {
-            error!(error = %e, "PostgreSQL connection error");
-        }
-    });
+            tokio::spawn(async move {
+                if let Err(e) = conn.await {
+                    error!(error = %e, "PostgreSQL connection error");
+                }
+            });
 
-    AsyncPgConnection::try_from(client).await
+            AsyncPgConnection::try_from(client).await
+        }
+    }
 }

--- a/chirpstack/src/integration/postgresql/mod.rs
+++ b/chirpstack/src/integration/postgresql/mod.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use anyhow::Result;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use diesel::{ConnectionError, ConnectionResult};
+use diesel::ConnectionResult;
 use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
 use diesel_async::pooled_connection::deadpool::{Object as DeadpoolObject, Pool as DeadpoolPool};
 use diesel_async::pooled_connection::{AsyncDieselConnectionManager, ManagerConfig};
@@ -12,12 +12,12 @@ use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
 use futures_util::FutureExt;
 use futures_util::future::BoxFuture;
-use tracing::{error, info};
+use tracing::info;
 use uuid::Uuid;
 
 use super::Integration as IntegrationTrait;
 use crate::config::{self, PostgresqlIntegration as Config};
-use crate::helpers::tls::get_root_certs;
+use crate::helpers::postgresql::establish_connection;
 use chirpstack_api::integration;
 use schema::{
     event_ack, event_integration, event_join, event_location, event_log, event_status,
@@ -232,26 +232,12 @@ impl Integration {
 fn pg_establish_connection(config: &str) -> BoxFuture<'_, ConnectionResult<AsyncPgConnection>> {
     let fut = async {
         let conf = config::get();
-
-        let root_certs = get_root_certs(if conf.integration.postgresql.ca_cert.is_empty() {
+        let ca_cert = if conf.integration.postgresql.ca_cert.is_empty() {
             None
         } else {
             Some(conf.integration.postgresql.ca_cert.clone())
-        })
-        .map_err(|e| ConnectionError::BadConnection(e.to_string()))?;
-        let rustls_config = rustls::ClientConfig::builder()
-            .with_root_certificates(root_certs)
-            .with_no_client_auth();
-        let tls = tokio_postgres_rustls::MakeRustlsConnect::new(rustls_config);
-        let (client, conn) = tokio_postgres::connect(config, tls)
-            .await
-            .map_err(|e| ConnectionError::BadConnection(e.to_string()))?;
-        tokio::spawn(async move {
-            if let Err(e) = conn.await {
-                error!(error = %e, "PostgreSQL connection error");
-            }
-        });
-        AsyncPgConnection::try_from(client).await
+        };
+        establish_connection(config, ca_cert).await
     };
     fut.boxed()
 }

--- a/chirpstack/src/storage/postgres.rs
+++ b/chirpstack/src/storage/postgres.rs
@@ -16,8 +16,7 @@ use prometheus_client::metrics::histogram::{Histogram, exponential_buckets};
 use scoped_futures::ScopedBoxFuture;
 
 use crate::config;
-
-use crate::helpers::tls::get_root_certs;
+use crate::helpers::postgresql::establish_connection;
 
 pub type AsyncPgPool = DeadpoolPool<AsyncPgConnection>;
 pub type AsyncPgPoolConnection = DeadpoolObject<AsyncPgConnection>;
@@ -71,26 +70,12 @@ pub fn setup(conf: &config::Postgresql) -> Result<()> {
 fn pg_establish_connection(config: &str) -> BoxFuture<'_, ConnectionResult<AsyncPgConnection>> {
     let fut = async {
         let conf = config::get();
-
-        let root_certs = get_root_certs(if conf.postgresql.ca_cert.is_empty() {
+        let ca_cert = if conf.postgresql.ca_cert.is_empty() {
             None
         } else {
             Some(conf.postgresql.ca_cert.clone())
-        })
-        .map_err(|e| ConnectionError::BadConnection(e.to_string()))?;
-        let rustls_config = rustls::ClientConfig::builder()
-            .with_root_certificates(root_certs)
-            .with_no_client_auth();
-        let tls = tokio_postgres_rustls::MakeRustlsConnect::new(rustls_config);
-        let (client, conn) = tokio_postgres::connect(config, tls)
-            .await
-            .map_err(|e| ConnectionError::BadConnection(e.to_string()))?;
-        tokio::spawn(async move {
-            if let Err(e) = conn.await {
-                error!(error = %e, "PostgreSQL connection error");
-            }
-        });
-        AsyncPgConnection::try_from(client).await
+        };
+        establish_connection(config, ca_cert).await
     };
     fut.boxed()
 }


### PR DESCRIPTION
Hi, I'm currently setting up chirpstack on NixOS. Since software on NixOS is usually not running in containers, unix socket connections are preferred for databases instead of TCP/IP.  For redis, unix sockets worked out of the box, but postgres would always throw errors even when explicitly stating `sslmode=disable` in the dsn like shown below.

```toml
[postgresql]
dsn = "postgresql:///chirpstack?user=chirpstack&host=/var/run/postgresql&sslmode=disable"
```
results in `Error: Error occurred while creating a new object: error performing TLS handshake`

I quickly threw together a patch, which now correctly works on my NixOS installation (ie chirpstack and chirpstack-gateway-bridge running and receiving packets). The important bit was passing `NoTls` to `tokio_postgres::connect` for the unix socket connection. Not sure how this will handle `sslmode=prefer` though.

Keep in mind that the code in this patch is generated by AI and probably not ready to be merged. Consider this PR more of a feature request / idea. I haven't used tokio_postgres and diesel before, so I'm not the right person to review this, but I'm happy to properly redo this patch again and get it merged into main. I see there is some interest in nixos support, so this patch would help with that :)

Best,
Martin