### PR TITLE
Bug/gateway admin UI validation missing add btn

### DIFF
--- a/ui/src/stores/SessionStore.ts
+++ b/ui/src/stores/SessionStore.ts
@@ -171,7 +171,9 @@ class SessionStore extends EventEmitter {
 
   isTenantGatewayAdmin = (tenantId: string): boolean => {
     for (const t of this.tenants) {
-      return t.getIsAdmin() || t.getIsGatewayAdmin();
+      if (t.getTenantId() === tenantId) {
+        return t.getIsAdmin() || t.getIsGatewayAdmin();
+      }
     }
 
     return false;


### PR DESCRIPTION
# Gateway Admin Users can't create new Gateways - UI Bug in Tenant Gateway Validation

## Bug / Issue
Not All GatewayAdmin Users can see the "Add Gateway" button, when standing on the gateways page `Tenants/Chirpstack/Gateways`.

This in only an issue when using multiple tenants in Chirpstack, with non-global-admin users assigned to tenants.

## Reproduction steps:
- Make multiple tenants
- Add a new non-admin user
- Make the new User GatewayAdmin and/or TenantAdmin on any Tenant but the first one.
- Make the new user attempt to create a new gateway on the tenant that the user has just become admin of.
- Notice the missing button.

## Note
The BE handles this issue correctly, this is only a UI bug. 
By changing the url manually the user can successfully create a new GW, on the admin privileged tenant. But will be signed out, due to unauthorized, when duing so on a different tenant, where the user does not have the rights. 

## The fix
The bug was located in the sessionStore logic. When validating if the user is TenantGatewayAdmin. The appended tenant_id was never used. 
Instead the method started a for-loop of all tenants, and then immediately returned the boolean value representing whether the user has admin permissions on that first tenant from the list. 
This method will therefore end up potentially validating for gateway rights on a different tenant than requesting.

After looking though the code, i do not belive it was intended to validate whether the user has gateway rights on ANY tenant - hence this solution, only validating the requested tenant, coded in the same style as the fellow methods.

“Closes #938 ”