### PR TITLE
Added support for max mac command error count configuration

### DIFF
--- a/chirpstack/src/cmd/configfile.rs
+++ b/chirpstack/src/cmd/configfile.rs
@@ -272,6 +272,13 @@ pub fn run() {
     {{/each}}
   ]
 
+  # Max mac-command error count.
+  #
+  # When a mac-command is nACKed for more than the configured value, then
+  # ChirpStack will stop sending this mac-command to the device. This setting
+  # prevents that Chirpstack will keep sending mac-commands on every downlink
+  # in case of a malfunctioning device.
+  max_mac_command_error_count={{ network.max_mac_command_error_count }}
 
   # Scheduler settings.
   [network.scheduler]

--- a/chirpstack/src/config.rs
+++ b/chirpstack/src/config.rs
@@ -171,6 +171,7 @@ pub struct Network {
     pub get_downlink_data_delay: Duration,
     pub mac_commands_disabled: bool,
     pub adr_plugins: Vec<String>,
+    pub max_mac_command_error_count: u32,
     pub scheduler: Scheduler,
 }
 
@@ -186,6 +187,7 @@ impl Default for Network {
             get_downlink_data_delay: Duration::from_millis(100),
             mac_commands_disabled: false,
             adr_plugins: vec![],
+            max_mac_command_error_count: 1,
             scheduler: Default::default(),
         }
     }

--- a/chirpstack/src/downlink/data.rs
+++ b/chirpstack/src/downlink/data.rs
@@ -2658,16 +2658,18 @@ fn filter_mac_commands(
     .collect();
 
     let mut filtered_mac_commands: Vec<lrwn::MACCommandSet> = Vec::new();
+    let conf = config::get();
+    let max_mac_command_error_count = conf.network.max_mac_command_error_count;
 
     'outer: for mac_command_set in mac_commands {
         for mac_command in &**mac_command_set {
-            // Check if it doesn't exceed the max error error count.
+            // Check if it doesn't exceed the max error count.
             if device_session
                 .mac_command_error_count
                 .get(&(mac_command.cid().to_u8() as u32))
                 .cloned()
                 .unwrap_or_default()
-                > 1
+                > max_mac_command_error_count
             {
                 continue 'outer;
             }


### PR DESCRIPTION
This PR aims to add support for a `max_mac_command_error_count` configuration. This used to exist in Chirpstack v3.