### PR TITLE
feat: forward LinkCheck MAC command to Pilot Things integration

### DIFF
--- a/api/proto/api/application.proto
+++ b/api/proto/api/application.proto
@@ -903,6 +903,11 @@ message PilotThingsIntegration {
 
   // Authentication token.
   string token = 3;
+
+  // Link-check endpoint URL.
+  // When set, a POST with link-check details is sent to this URL on each
+  // LinkCheckReq received from a device. Leave empty to disable.
+  string link_check_endpoint = 4;
 }
 
 message CreatePilotThingsIntegrationRequest {

--- a/api/proto/integration/integration.proto
+++ b/api/proto/integration/integration.proto
@@ -314,6 +314,43 @@ message LocationEvent {
   common.Location location = 4;
 }
 
+// LinkCheckGwRxInfo contains per-gateway reception info for a link-check request.
+message LinkCheckGwRxInfo {
+  // Gateway ID.
+  string gateway_id = 1;
+
+  // RSSI.
+  int32 rssi = 2;
+
+  // SNR.
+  float snr = 3;
+
+  // Link margin in dB for this gateway.
+  uint32 margin = 4;
+}
+
+// LinkCheckEvent is the message sent when a device sent a link-check request.
+message LinkCheckEvent {
+  // Deduplication ID (UUID).
+  string deduplication_id = 1;
+
+  // Timestamp.
+  google.protobuf.Timestamp time = 2;
+
+  // Device info.
+  DeviceInfo device_info = 3;
+
+  // Link margin in dB of the best received link-check request.
+  // This is the value returned in LinkCheckAns to the device.
+  uint32 margin = 4;
+
+  // Number of gateways that received the link-check request.
+  uint32 gw_cnt = 5;
+
+  // Per-gateway RX info with individual SNR, RSSI and margin.
+  repeated LinkCheckGwRxInfo gw_rx_info = 6;
+}
+
 // DownlinkCommand is the command to enqueue a downlink payload for the given
 // device.
 message DownlinkCommand {

--- a/chirpstack/src/api/application.rs
+++ b/chirpstack/src/api/application.rs
@@ -1358,6 +1358,7 @@ impl ApplicationService for Application {
                 application::PilotThingsConfiguration {
                     server: req_int.server.clone(),
                     token: req_int.token.clone(),
+                    link_check_endpoint: req_int.link_check_endpoint.clone(),
                 },
             ),
             ..Default::default()
@@ -1398,6 +1399,7 @@ impl ApplicationService for Application {
                     application_id: app_id.to_string(),
                     server: conf.server.clone(),
                     token: conf.token.clone(),
+                    link_check_endpoint: conf.link_check_endpoint.clone(),
                 }),
             });
             resp.metadata_mut()
@@ -1437,6 +1439,7 @@ impl ApplicationService for Application {
                 application::PilotThingsConfiguration {
                     server: req_int.server.clone(),
                     token: req_int.token.clone(),
+                    link_check_endpoint: req_int.link_check_endpoint.clone(),
                 },
             ),
             ..Default::default()

--- a/chirpstack/src/integration/mock.rs
+++ b/chirpstack/src/integration/mock.rs
@@ -23,6 +23,8 @@ static STATUS_EVENTS: LazyLock<RwLock<Vec<integration::StatusEvent>>> =
     LazyLock::new(|| RwLock::new(Vec::new()));
 static LOCATION_EVENTS: LazyLock<RwLock<Vec<integration::LocationEvent>>> =
     LazyLock::new(|| RwLock::new(Vec::new()));
+static LINK_CHECK_EVENTS: LazyLock<RwLock<Vec<integration::LinkCheckEvent>>> =
+    LazyLock::new(|| RwLock::new(Vec::new()));
 
 pub async fn reset() {
     UPLINK_EVENTS.write().await.drain(..);
@@ -32,6 +34,7 @@ pub async fn reset() {
     LOG_EVENTS.write().await.drain(..);
     STATUS_EVENTS.write().await.drain(..);
     LOCATION_EVENTS.write().await.drain(..);
+    LINK_CHECK_EVENTS.write().await.drain(..);
 }
 
 pub struct Integration {}
@@ -98,6 +101,15 @@ impl IntegrationTrait for Integration {
         pl: &integration::LocationEvent,
     ) -> Result<()> {
         LOCATION_EVENTS.write().await.push(pl.clone());
+        Ok(())
+    }
+
+    async fn link_check_event(
+        &self,
+        _vars: &HashMap<String, String>,
+        pl: &integration::LinkCheckEvent,
+    ) -> Result<()> {
+        LINK_CHECK_EVENTS.write().await.push(pl.clone());
         Ok(())
     }
 }
@@ -180,4 +192,8 @@ pub async fn get_status_events() -> Vec<integration::StatusEvent> {
 
 pub async fn get_location_events() -> Vec<integration::LocationEvent> {
     LOCATION_EVENTS.write().await.drain(..).collect()
+}
+
+pub async fn get_link_check_events() -> Vec<integration::LinkCheckEvent> {
+    LINK_CHECK_EVENTS.write().await.drain(..).collect()
 }

--- a/chirpstack/src/integration/mod.rs
+++ b/chirpstack/src/integration/mod.rs
@@ -129,6 +129,14 @@ pub trait Integration {
         vars: &HashMap<String, String>,
         pl: &integration::LocationEvent,
     ) -> Result<()>;
+
+    async fn link_check_event(
+        &self,
+        _vars: &HashMap<String, String>,
+        _pl: &integration::LinkCheckEvent,
+    ) -> Result<()> {
+        Ok(())
+    }
 }
 
 // Returns a Vec of integrations for the given Application ID.
@@ -470,6 +478,48 @@ async fn _location_event(
     }
     for (i, _) in global_ints.iter().enumerate() {
         futures.push(global_ints[i].location_event(vars, pl));
+    }
+
+    for e in join_all(futures).await {
+        e?;
+    }
+
+    Ok(())
+}
+
+pub async fn link_check_event(
+    application_id: Uuid,
+    vars: &HashMap<String, String>,
+    pl: &integration::LinkCheckEvent,
+) {
+    tokio::spawn({
+        let vars = vars.clone();
+        let pl = pl.clone();
+
+        async move {
+            if let Err(err) = _link_check_event(application_id, &vars, &pl).await {
+                warn!(application_id = %application_id, error = %err.full(), "Link-check event error");
+            }
+        }
+    });
+}
+
+async fn _link_check_event(
+    application_id: Uuid,
+    vars: &HashMap<String, String>,
+    pl: &integration::LinkCheckEvent,
+) -> Result<()> {
+    let app_ints = for_application_id(application_id)
+        .await
+        .context("Get integrations for application")?;
+    let global_ints = GLOBAL_INTEGRATIONS.read().await;
+    let mut futures = Vec::new();
+
+    for (i, _) in app_ints.iter().enumerate() {
+        futures.push(app_ints[i].link_check_event(vars, pl));
+    }
+    for (i, _) in global_ints.iter().enumerate() {
+        futures.push(global_ints[i].link_check_event(vars, pl));
     }
 
     for e in join_all(futures).await {

--- a/chirpstack/src/integration/pilot_things.rs
+++ b/chirpstack/src/integration/pilot_things.rs
@@ -29,6 +29,7 @@ fn get_client() -> Client {
 pub struct Integration {
     server: String,
     token: String,
+    link_check_endpoint: String,
 }
 
 impl Integration {
@@ -38,6 +39,7 @@ impl Integration {
         Integration {
             server: conf.server.clone(),
             token: conf.token.clone(),
+            link_check_endpoint: conf.link_check_endpoint.clone(),
         }
     }
 }
@@ -119,6 +121,37 @@ impl IntegrationTrait for Integration {
     ) -> Result<()> {
         Ok(())
     }
+
+    async fn link_check_event(
+        &self,
+        _vars: &HashMap<String, String>,
+        pl: &integration::LinkCheckEvent,
+    ) -> Result<()> {
+        if self.link_check_endpoint.is_empty() {
+            return Ok(());
+        }
+
+        let endpoint = self.link_check_endpoint.clone();
+        let di = pl.device_info.as_ref().unwrap();
+        info!(dev_eui = %di.dev_eui, event = "link_check", endpoint = %endpoint, "Sending link-check event");
+
+        let pl = LinkCheckPayload::from_link_check_event(pl);
+        let b = serde_json::to_string(&pl)?;
+
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+
+        let res = get_client()
+            .post(endpoint)
+            .body(b)
+            .query(&[("token", self.token.clone())])
+            .headers(headers)
+            .send()
+            .await?;
+
+        let _ = res.error_for_status()?;
+        Ok(())
+    }
 }
 
 #[derive(Serialize)]
@@ -146,6 +179,50 @@ struct UplinkMetadata {
     pub rf_chain: u32,
     pub antenna: u32,
     pub board: u32,
+}
+
+#[derive(Serialize)]
+struct LinkCheckPayload {
+    #[serde(rename = "devEUI")]
+    pub dev_eui: String,
+    #[serde(rename = "deviceName")]
+    pub device_name: String,
+    pub margin: u32,
+    #[serde(rename = "gwCnt")]
+    pub gw_cnt: u32,
+    pub gateways: Vec<LinkCheckGwInfo>,
+}
+
+#[derive(Serialize)]
+struct LinkCheckGwInfo {
+    #[serde(rename = "gatewayId")]
+    pub gateway_id: String,
+    pub rssi: i32,
+    #[serde(rename = "lorasnr")]
+    pub lora_snr: f32,
+    pub margin: u32,
+}
+
+impl LinkCheckPayload {
+    fn from_link_check_event(pl: &integration::LinkCheckEvent) -> Self {
+        let di = pl.device_info.as_ref().unwrap();
+        LinkCheckPayload {
+            dev_eui: di.dev_eui.clone(),
+            device_name: di.device_name.clone(),
+            margin: pl.margin,
+            gw_cnt: pl.gw_cnt,
+            gateways: pl
+                .gw_rx_info
+                .iter()
+                .map(|g| LinkCheckGwInfo {
+                    gateway_id: g.gateway_id.clone(),
+                    rssi: g.rssi,
+                    lora_snr: g.snr,
+                    margin: g.margin,
+                })
+                .collect(),
+        }
+    }
 }
 
 impl UplinkPayload {

--- a/chirpstack/src/maccommand/link_check.rs
+++ b/chirpstack/src/maccommand/link_check.rs
@@ -1,13 +1,20 @@
 use anyhow::Result;
+use chrono::{DateTime, Utc};
 use tracing::{info, warn};
 
+use crate::api::helpers::ToProto;
+use crate::integration;
+use crate::storage::{application, device, device_profile, tenant};
+use crate::uplink::{UplinkFrameSet, helpers};
 use crate::config;
-use crate::storage::device;
-use crate::uplink::UplinkFrameSet;
 use chirpstack_api::gw;
+use chirpstack_api::integration as integration_pb;
 
-pub fn handle(
+pub async fn handle(
     ufs: &UplinkFrameSet,
+    tenant: &tenant::Tenant,
+    app: &application::Application,
+    dp: &device_profile::DeviceProfile,
     dev: &device::Device,
     block: &lrwn::MACCommandSet,
 ) -> Result<Option<lrwn::MACCommandSet>> {
@@ -27,33 +34,71 @@ pub fn handle(
         .as_ref()
         .ok_or_else(|| anyhow!("parameters can not be None"))?;
 
-    // For non-LoRa modulations, the margin will be set to 0, as it can not be calculated.
-    // This way, at least the gw_cnt can be provided and the end-device is able to confirm
-    // it is still connected.
-    let margin = match mod_params {
+    let required_snr: Option<f32> = match mod_params {
         gw::modulation::Parameters::Lora(pl) => {
-            let required_snr = config::get_required_snr_for_sf(pl.spreading_factor as u8)?;
-            let mut max_snr: f32 = 0.0;
-
-            for (i, rx_info) in ufs.rx_info_set.iter().enumerate() {
-                if i == 0 || rx_info.snr > max_snr {
-                    max_snr = rx_info.snr;
-                }
-            }
-
-            let margin = max_snr - required_snr;
-            if margin < 0.0 { 0.0 } else { margin }
+            Some(config::get_required_snr_for_sf(pl.spreading_factor as u8)?)
         }
         _ => {
             warn!("Modulation does not provide margin to LinkCheckReq");
-            0.0
+            None
         }
     };
 
-    // We always return a LinkCheckAns, even
+    let gw_rx_info: Vec<integration_pb::LinkCheckGwRxInfo> = ufs
+        .rx_info_set
+        .iter()
+        .map(|rx| {
+            let gw_margin = required_snr
+                .map(|snr| {
+                    let m = rx.snr - snr;
+                    if m < 0.0 { 0.0 } else { m }
+                })
+                .unwrap_or(0.0);
+            integration_pb::LinkCheckGwRxInfo {
+                gateway_id: rx.gateway_id.clone(),
+                rssi: rx.rssi,
+                snr: rx.snr,
+                margin: gw_margin as u32,
+            }
+        })
+        .collect();
+
+    let best_margin = gw_rx_info.iter().map(|g| g.margin).max().unwrap_or(0);
+
+    let mut tags = (*app.tags).clone();
+    tags.extend((*dp.tags).clone());
+    tags.extend((*dev.tags).clone());
+
+    let rx_time: DateTime<Utc> = helpers::get_rx_timestamp(&ufs.rx_info_set).into();
+
+    integration::link_check_event(
+        app.id.into(),
+        &dev.variables,
+        &integration_pb::LinkCheckEvent {
+            deduplication_id: ufs.uplink_set_id.to_string(),
+            time: Some(rx_time.into()),
+            device_info: Some(integration_pb::DeviceInfo {
+                tenant_id: tenant.id.to_string(),
+                tenant_name: tenant.name.clone(),
+                application_id: app.id.to_string(),
+                application_name: app.name.to_string(),
+                device_profile_id: dp.id.to_string(),
+                device_profile_name: dp.name.clone(),
+                device_name: dev.name.clone(),
+                device_class_enabled: dev.enabled_class.to_proto().into(),
+                dev_eui: dev.dev_eui.to_string(),
+                tags,
+            }),
+            margin: best_margin,
+            gw_cnt: ufs.rx_info_set.len() as u32,
+            gw_rx_info,
+        },
+    )
+    .await;
+
     Ok(Some(lrwn::MACCommandSet::new(vec![
         lrwn::MACCommand::LinkCheckAns(lrwn::LinkCheckAnsPayload {
-            margin: margin as u8,
+            margin: best_margin as u8,
             gw_cnt: ufs.rx_info_set.len() as u8,
         }),
     ])))
@@ -62,11 +107,21 @@ pub fn handle(
 #[cfg(test)]
 pub mod test {
     use super::*;
+    use crate::integration::mock;
+    use crate::{integration, test};
+    use chirpstack_api::gw;
+    use lrwn::EUI64;
     use std::collections::HashMap;
+    use std::str::FromStr;
+    use std::time::Duration;
+    use tokio::time::sleep;
     use uuid::Uuid;
 
-    #[test]
-    fn test_handle() {
+    #[tokio::test]
+    async fn test_handle() {
+        let _guard = test::prepare().await;
+        integration::set_mock().await;
+
         let ufs = UplinkFrameSet {
             uplink_set_id: Uuid::new_v4(),
             dr: 0,
@@ -94,11 +149,15 @@ pub mod test {
             },
             rx_info_set: vec![
                 gw::UplinkRxInfo {
+                    gateway_id: "0101010101010101".into(),
                     snr: -2.0,
+                    rssi: -110,
                     ..Default::default()
                 },
                 gw::UplinkRxInfo {
+                    gateway_id: "0202020202020202".into(),
                     snr: 2.0,
+                    rssi: -100,
                     ..Default::default()
                 },
             ],
@@ -110,11 +169,44 @@ pub mod test {
             roaming_meta_data: None,
         };
 
-        let dev: device::Device = Default::default();
+        let tenant = tenant::create(tenant::Tenant {
+            name: "test-tenant".into(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+        let app = application::create(application::Application {
+            tenant_id: tenant.id,
+            name: "test-app".into(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+        let dp = device_profile::create(device_profile::DeviceProfile {
+            tenant_id: Some(tenant.id),
+            name: "test-dp".into(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+        let dev = device::create(device::Device {
+            application_id: app.id,
+            device_profile_id: dp.id,
+            dev_eui: EUI64::from_str("0102030405060708").unwrap(),
+            name: "test-device".into(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
         let block = lrwn::MACCommandSet::new(vec![lrwn::MACCommand::LinkCheckReq]);
 
-        let resp = handle(&ufs, &dev, &block).unwrap();
+        let resp = handle(&ufs, &tenant, &app, &dp, &dev, &block)
+            .await
+            .unwrap();
 
+        // required_snr for SF10 = -15 dB
+        // gw1: snr -2.0 - (-15.0) = 13, gw2: snr 2.0 - (-15.0) = 17 → best = 17
         assert_eq!(
             Some(lrwn::MACCommandSet::new(vec![
                 lrwn::MACCommand::LinkCheckAns(lrwn::LinkCheckAnsPayload {
@@ -124,5 +216,26 @@ pub mod test {
             ])),
             resp
         );
+
+        // Integration events are handled async.
+        sleep(Duration::from_millis(100)).await;
+
+        let events = mock::get_link_check_events().await;
+        assert_eq!(1, events.len());
+        let ev = &events[0];
+        assert_eq!(ufs.uplink_set_id.to_string(), ev.deduplication_id);
+        assert_eq!(17, ev.margin);
+        assert_eq!(2, ev.gw_cnt);
+        assert_eq!(2, ev.gw_rx_info.len());
+
+        let gw1 = ev.gw_rx_info.iter().find(|g| g.gateway_id == "0101010101010101").unwrap();
+        assert_eq!(-110, gw1.rssi);
+        assert_eq!(-2.0, gw1.snr);
+        assert_eq!(13, gw1.margin);
+
+        let gw2 = ev.gw_rx_info.iter().find(|g| g.gateway_id == "0202020202020202").unwrap();
+        assert_eq!(-100, gw2.rssi);
+        assert_eq!(2.0, gw2.snr);
+        assert_eq!(17, gw2.margin);
     }
 }

--- a/chirpstack/src/maccommand/mod.rs
+++ b/chirpstack/src/maccommand/mod.rs
@@ -136,7 +136,9 @@ async fn handle(
         lrwn::CID::DeviceModeInd => device_mode_ind::handle(dev, block).await,
         lrwn::CID::DeviceTimeReq => device_time::handle(uplink_frame_set, dev, block),
         lrwn::CID::LinkADRAns => link_adr::handle(uplink_frame_set, dev, block, pending_block),
-        lrwn::CID::LinkCheckReq => link_check::handle(uplink_frame_set, dev, block),
+        lrwn::CID::LinkCheckReq => {
+            link_check::handle(uplink_frame_set, tenant, app, dp, dev, block).await
+        }
         lrwn::CID::NewChannelAns => new_channel::handle(dev, block, pending_block, region_conf),
         lrwn::CID::PingSlotChannelAns => ping_slot_channel::handle(dev, block, pending_block),
         lrwn::CID::PingSlotInfoReq => ping_slot_info::handle(dev, block),

--- a/chirpstack/src/storage/application.rs
+++ b/chirpstack/src/storage/application.rs
@@ -252,6 +252,7 @@ pub struct AzureServiceBusConfiguration {
 pub struct PilotThingsConfiguration {
     pub server: String,
     pub token: String,
+    pub link_check_endpoint: String,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

- Adds a new `LinkCheckEvent` proto message (with per-gateway `LinkCheckGwRxInfo`) fired each time a device sends a `LinkCheckReq` MAC command
- Adds a configurable `link_check_endpoint` field to the Pilot Things integration — leave empty to disable, set to any HTTP endpoint to receive the event
- All other integrations are unaffected (default no-op via trait default method)

## Details

**New proto messages** (`api/proto/integration/integration.proto`):
- `LinkCheckGwRxInfo` — gateway ID, RSSI, SNR, per-gateway link margin
- `LinkCheckEvent` — deduplication ID, timestamp, device info, best margin, gw_cnt, repeated `LinkCheckGwRxInfo`

**Integration trait** (`chirpstack/src/integration/mod.rs`):
- `link_check_event` added as a default no-op — no changes required in any existing integration

**MAC command handler** (`chirpstack/src/maccommand/link_check.rs`):
- Now async; accepts tenant/app/dp context (same pattern as `dev_status`)
- Computes per-gateway margin (`snr_i - required_snr_for_sf`, clamped to 0)
- Fires `integration::link_check_event` before returning `LinkCheckAns`

**Pilot Things** (`chirpstack/src/integration/pilot_things.rs`):
- New `link_check_endpoint` config field (proto field 4, storage, API create/get/update)
- POSTs JSON payload `{ devEUI, deviceName, margin, gwCnt, gateways: [{ gatewayId, rssi, lorasnr, margin }] }` to the configured URL
- Skips silently if `link_check_endpoint` is empty (backwards compatible)

## Test plan

- [ ] Existing Pilot Things uplink test still passes
- [ ] New `link_check::test::test_handle` verifies `LinkCheckAns` values and integration event (margin=17, gw_cnt=2, per-gateway margin for SF10)
- [ ] Pilot Things integration with empty `link_check_endpoint` → no HTTP call made
- [ ] Pilot Things integration with endpoint set → POST fired with correct JSON on each LinkCheckReq

🤖 Generated with [Claude Code](https://claude.com/claude-code)