### PR TITLE
fix: typo in FUOTA start confirm

### DIFF
--- a/ui/src/views/fuota/FuotaDeploymentLayout.tsx
+++ b/ui/src/views/fuota/FuotaDeploymentLayout.tsx
@@ -157,7 +157,7 @@ function FuotaDeploymentLayout(props: IProps) {
               <Popconfirm
                 placement="left"
                 title="Start deployment"
-                description="Are you sure you want to start the deploymen? Once started, you will not be able to make changes."
+                description="Are you sure you want to start the deployment? Once started, you will not be able to make changes."
                 onConfirm={startFuotaDeployment}
               >
                 <Button type="primary" disabled={getFuotaDeploymentResponse.getStartedAt() !== undefined}>


### PR DESCRIPTION
There's a typo on the `Start deployment` section on the UI. 

<img width="1855" height="275" alt="image" src="https://github.com/user-attachments/assets/2ecd37af-6e8b-4e5d-a88d-b938951e50fa" />
