### PR TITLE
fix: codec jsdoc

### DIFF
--- a/ui/src/views/device-profiles/CreateDeviceProfile.tsx
+++ b/ui/src/views/device-profiles/CreateDeviceProfile.tsx
@@ -44,11 +44,11 @@ function CreateDeviceProfile(props: IProps) {
  * @param {number} input.fPort Uplink fPort.
  * @param {Record<string, string>} input.variables Object containing the configured device variables.
  * 
- * @returns {{data: object, errors: string[], warnings: string[]}}
+ * @returns {{data: object, errors?: string[], warnings?: string[]}}
  * An object containing:
  * - data: Object representing the decoded payload.
- * - errors: An array of errors (optional).
- * - warnings: An array of warnings (optional).
+ * - errors: An array of errors (currently unused).
+ * - warnings: An array of warnings (currently unused).
  */
 function decodeUplink(input) {
   return {
@@ -65,12 +65,12 @@ function decodeUplink(input) {
  * @param {object} input.data Object representing the payload that must be encoded.
  * @param {Record<string, string>} input.variables Object containing the configured device variables.
  * 
- * @returns {{bytes: number[], fPort: number, errors: string[], warnings: string[]}}
+ * @returns {{bytes: number[], fPort?: number, errors?: string[], warnings?: string[]}}
  * An object containing:
  * - bytes: Byte array containing the downlink payload.
- * - fPort: The downlink LoRaWAN fPort.
- * - errors: An array of errors (optional).
- * - warnings: An array of warnings (optional).
+ * - fPort: The downlink LoRaWAN fPort. (falls back to provided fPort)
+ * - errors: An array of errors (currently unused).
+ * - warnings: An array of warnings (currently unused).
  */
 function encodeDownlink(input) {
   return {

--- a/ui/src/views/device-profiles/CreateDeviceProfile.tsx
+++ b/ui/src/views/device-profiles/CreateDeviceProfile.tsx
@@ -47,8 +47,8 @@ function CreateDeviceProfile(props: IProps) {
  * @returns {{data: object, errors?: string[], warnings?: string[]}}
  * An object containing:
  * - data: Object representing the decoded payload.
- * - errors: An array of errors (currently unused).
- * - warnings: An array of warnings (currently unused).
+ * - errors: An array of errors (optional).
+ * - warnings: An array of warnings (optional).
  */
 function decodeUplink(input) {
   return {
@@ -69,8 +69,8 @@ function decodeUplink(input) {
  * An object containing:
  * - bytes: Byte array containing the downlink payload.
  * - fPort: The downlink LoRaWAN fPort. (falls back to provided fPort)
- * - errors: An array of errors (currently unused).
- * - warnings: An array of warnings (currently unused).
+ * - errors: An array of errors (optional).
+ * - warnings: An array of warnings (optional).
  */
 function encodeDownlink(input) {
   return {


### PR DESCRIPTION
The codec jsdoc now requires

- `errors` and `warnings` for `decodeUplink`
- `fPort`, `errors` and `warnings` for `encodeDownlink`

`errors` and `warnings` is unused
`fPort` defaults to the one provided (e.g. in the ui) and if none it errors

therefore these all should be optional

`warnings` is completely optional per spec
`errors` is mandatory per spec if the codec failed
`fPort` is mandatory per spec

technically if errors is defined (and has atleast one entry?) the codec should fail
and technically data is optional if errors is set (but i don't think it makes sense to represent that in the jsdoc)

