### PR TITLE
add support for session_expiry_interval (mqtt5+)

### DIFF
--- a/chirpstack/configuration/region_as923.toml
+++ b/chirpstack/configuration/region_as923.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_as923_2.toml
+++ b/chirpstack/configuration/region_as923_2.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_as923_3.toml
+++ b/chirpstack/configuration/region_as923_3.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_as923_4.toml
+++ b/chirpstack/configuration/region_as923_4.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_au915_0.toml
+++ b/chirpstack/configuration/region_au915_0.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_au915_1.toml
+++ b/chirpstack/configuration/region_au915_1.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_au915_2.toml
+++ b/chirpstack/configuration/region_au915_2.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_au915_3.toml
+++ b/chirpstack/configuration/region_au915_3.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_au915_4.toml
+++ b/chirpstack/configuration/region_au915_4.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_au915_5.toml
+++ b/chirpstack/configuration/region_au915_5.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_au915_6.toml
+++ b/chirpstack/configuration/region_au915_6.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_au915_7.toml
+++ b/chirpstack/configuration/region_au915_7.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_cn470_0.toml
+++ b/chirpstack/configuration/region_cn470_0.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_cn470_1.toml
+++ b/chirpstack/configuration/region_cn470_1.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_cn470_10.toml
+++ b/chirpstack/configuration/region_cn470_10.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_cn470_11.toml
+++ b/chirpstack/configuration/region_cn470_11.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_cn470_2.toml
+++ b/chirpstack/configuration/region_cn470_2.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_cn470_3.toml
+++ b/chirpstack/configuration/region_cn470_3.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_cn470_4.toml
+++ b/chirpstack/configuration/region_cn470_4.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_cn470_5.toml
+++ b/chirpstack/configuration/region_cn470_5.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_cn470_6.toml
+++ b/chirpstack/configuration/region_cn470_6.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_cn470_7.toml
+++ b/chirpstack/configuration/region_cn470_7.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_cn470_8.toml
+++ b/chirpstack/configuration/region_cn470_8.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_cn470_9.toml
+++ b/chirpstack/configuration/region_cn470_9.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_cn779.toml
+++ b/chirpstack/configuration/region_cn779.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_eu433.toml
+++ b/chirpstack/configuration/region_eu433.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_eu868.toml
+++ b/chirpstack/configuration/region_eu868.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_in865.toml
+++ b/chirpstack/configuration/region_in865.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_ism2400.toml
+++ b/chirpstack/configuration/region_ism2400.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_kr920.toml
+++ b/chirpstack/configuration/region_kr920.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_ru864.toml
+++ b/chirpstack/configuration/region_ru864.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_us915_0.toml
+++ b/chirpstack/configuration/region_us915_0.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_us915_1.toml
+++ b/chirpstack/configuration/region_us915_1.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_us915_2.toml
+++ b/chirpstack/configuration/region_us915_2.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_us915_3.toml
+++ b/chirpstack/configuration/region_us915_3.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_us915_4.toml
+++ b/chirpstack/configuration/region_us915_4.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_us915_5.toml
+++ b/chirpstack/configuration/region_us915_5.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_us915_6.toml
+++ b/chirpstack/configuration/region_us915_6.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/configuration/region_us915_7.toml
+++ b/chirpstack/configuration/region_us915_7.toml
@@ -82,6 +82,15 @@
         # that no messages saved by the broker for this client should be delivered.
         clean_session = false
 
+        # Session expiry interval (MQTT 5+).
+        #
+        # This defines how long the broker keeps the session state after the client
+        # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+        # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+        # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+        # when reconnecting.
+        session_expiry_interval="0s"
+
         # Client ID
         #
         # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/src/cmd/configfile.rs
+++ b/chirpstack/src/cmd/configfile.rs
@@ -477,6 +477,15 @@ pub fn run() {
     # that no messages saved by the broker for this client should be delivered.
     clean_session={{ integration.mqtt.clean_session }}
 
+    # Session expiry interval (MQTT 5+).
+    #
+    # This defines how long the broker keeps the session state after the client
+    # disconnects. Only applicable when the broker supports MQTT 5 or higher.
+    # Leave unset or set to 0 to expire immediately (stateless). Use a non-zero
+    # value (e.g. 10m or 24h) to resume subscriptions and queued QoS 1/2 messages
+    # when reconnecting.
+    session_expiry_interval="{{ integration.mqtt.session_expiry_interval }}"
+
     # Client ID
     #
     # Set the client id to be used by this client when connecting to the MQTT

--- a/chirpstack/src/config.rs
+++ b/chirpstack/src/config.rs
@@ -303,6 +303,8 @@ pub struct MqttIntegration {
     pub password: String,
     pub qos: usize,
     pub clean_session: bool,
+    #[serde(with = "humantime_serde")]
+    pub session_expiry_interval: Duration,
     pub client_id: String,
     pub ca_cert: String,
     pub tls_cert: String,
@@ -326,6 +328,7 @@ impl Default for MqttIntegration {
             password: "".into(),
             qos: 0,
             clean_session: false,
+            session_expiry_interval: Duration::from_secs(0),
             client_id: "".into(),
             ca_cert: "".into(),
             tls_cert: "".into(),
@@ -764,6 +767,8 @@ pub struct GatewayBackendMqtt {
     pub password: String,
     pub qos: usize,
     pub clean_session: bool,
+    #[serde(with = "humantime_serde")]
+    pub session_expiry_interval: Duration,
     pub client_id: String,
     pub ca_cert: String,
     pub tls_cert: String,
@@ -786,6 +791,7 @@ impl Default for GatewayBackendMqtt {
             password: "".into(),
             qos: 0,
             clean_session: false,
+            session_expiry_interval: Duration::from_secs(0),
             client_id: "".into(),
             ca_cert: "".into(),
             tls_cert: "".into(),

--- a/chirpstack/src/gateway/backend/mqtt.rs
+++ b/chirpstack/src/gateway/backend/mqtt.rs
@@ -122,6 +122,7 @@ impl<'a> MqttBackend<'a> {
         let mut mqtt_opts =
             MqttOptions::parse_url(format!("{}?client_id={}", conf.server, client_id))?;
         mqtt_opts.set_clean_start(conf.clean_session);
+        mqtt_opts.set_session_expiry_interval(Some(conf.session_expiry_interval.as_secs() as u32));
         mqtt_opts.set_keep_alive(conf.keep_alive_interval);
         if !conf.username.is_empty() || !conf.password.is_empty() {
             mqtt_opts.set_credentials(&conf.username, &conf.password);

--- a/chirpstack/src/integration/mqtt.rs
+++ b/chirpstack/src/integration/mqtt.rs
@@ -91,6 +91,7 @@ impl<'a> Integration<'a> {
         let mut mqtt_opts =
             MqttOptions::parse_url(format!("{}?client_id={}", conf.server, client_id))?;
         mqtt_opts.set_clean_start(conf.clean_session);
+        mqtt_opts.set_session_expiry_interval(Some(conf.session_expiry_interval.as_secs() as u32));
         mqtt_opts.set_keep_alive(conf.keep_alive_interval);
         if !conf.username.is_empty() || !conf.password.is_empty() {
             mqtt_opts.set_credentials(&conf.username, &conf.password);
@@ -142,7 +143,7 @@ impl<'a> Integration<'a> {
         };
 
         // connect
-        info!(server_uri = %conf.server, client_id = %client_id, clean_session = conf.clean_session, "Connecting to MQTT broker");
+        info!(server_uri = %conf.server, client_id = %client_id, clean_session = conf.clean_session, session_expiry_interval = %conf.session_expiry_interval.as_secs(), "Connecting to MQTT broker");
 
         // (Re)subscribe loop
         tokio::spawn({
@@ -496,6 +497,7 @@ pub mod test {
             json: true,
             server: env::var("TEST_MOSQUITTO_SERVER").unwrap(),
             clean_session: true,
+            session_expiry_interval: Duration::from_secs(3600),
             ..Default::default()
         };
         let i = Integration::new(&conf).await.unwrap();


### PR DESCRIPTION
# Summary
This PR adds support for configuring the MQTT 5 `session_expiry_interval` property (supported by rumqttc since v0.25.0).

Changes in this PR:
- Adds a configuration option for MQTT 5 `session_expiry_interval`.
- Preserves existing behavior when the option is not configured.

# Background
Before MQTT 5, session persistence was controlled by the `clean_session` flag.

In MQTT 5, this behavior is split into two separate concepts:
- `clean_start`: determines whether an existing session is discarded when establishing a new connection.
- `session_expiry_interval`: determines how long the session is retained after the client disconnects.

Currently, ChirpStack only exposes the legacy `clean_session` configuration option, which is internally mapped to the `rumqttc` `clean_start` setting when using MQTT 5. However, there is currently no way to configure the MQTT 5 `session_expiry_interval` property.

As a result, MQTT 5 users cannot control session retention behavior through ChirpStack configuration.

# Outcome
This change allows MQTT 5 users to fully control session lifecycle behavior and aligns ChirpStack's MQTT 5 configuration with the MQTT 5 specification.