### PR TITLE
fix: set dev_eui_relayed when saving relayed join-accept downlink-frame

### DIFF
--- a/chirpstack/src/downlink/join.rs
+++ b/chirpstack/src/downlink/join.rs
@@ -592,6 +592,7 @@ impl JoinAccept<'_> {
 
         let df = chirpstack_api::internal::DownlinkFrame {
             dev_eui: relay_ctx.device.dev_eui.to_be_bytes().to_vec(),
+            dev_eui_relayed: self.device.dev_eui.to_be_bytes().to_vec(),
             downlink_id: self.downlink_frame.downlink_id,
             downlink_frame: Some(self.downlink_frame.clone()),
             nwk_s_enc_key: relay_ds.nwk_s_enc_key.clone(),

--- a/chirpstack/src/downlink/tx_ack.rs
+++ b/chirpstack/src/downlink/tx_ack.rs
@@ -145,30 +145,42 @@ impl TxAck {
             self.increment_a_f_cnt_down()?;
             self.save_device_session().await?;
 
-            // Get data of relayed device.
-            self.get_device_data_relayed().await?;
-
-            // Handle end-device frame-counter increment + queue item.
-            if self.is_application_payload_relayed() {
-                self.get_device_queue_item().await?;
-                if self.is_unconfirmed_downlink_relayed() {
-                    self.delete_device_queue_item().await?;
-                }
-
-                if self.is_confirmed_downlink_relayed() {
-                    self.set_device_queue_item_pending().await?;
-                    self.set_device_session_conf_f_cnt_relayed()?;
-                }
-
-                self.increment_a_f_cnt_down_relayed()?;
-                self.save_device_session_relayed().await?;
-
-                // Log tx ack event.
+            // A ForwardDownlinkReq always relates to a relayed device and thus the
+            // dev_eui_relayed should always be set, but guard against an empty value
+            // anyway as this would abort the handling below (and thus skip the
+            // frame-logging).
+            if !self
+                .downlink_frame
+                .as_ref()
+                .unwrap()
+                .dev_eui_relayed
+                .is_empty()
+            {
+                // Get data of relayed device.
                 self.get_device_data_relayed().await?;
-                self.send_tx_ack_event_relayed().await?;
-            } else if self.is_mac_only_downlink_relayed() {
-                self.increment_n_f_cnt_down_relayed()?;
-                self.save_device_session_relayed().await?;
+
+                // Handle end-device frame-counter increment + queue item.
+                if self.is_application_payload_relayed() {
+                    self.get_device_queue_item().await?;
+                    if self.is_unconfirmed_downlink_relayed() {
+                        self.delete_device_queue_item().await?;
+                    }
+
+                    if self.is_confirmed_downlink_relayed() {
+                        self.set_device_queue_item_pending().await?;
+                        self.set_device_session_conf_f_cnt_relayed()?;
+                    }
+
+                    self.increment_a_f_cnt_down_relayed()?;
+                    self.save_device_session_relayed().await?;
+
+                    // Log tx ack event.
+                    self.get_device_data_relayed().await?;
+                    self.send_tx_ack_event_relayed().await?;
+                } else if self.is_mac_only_downlink_relayed() {
+                    self.increment_n_f_cnt_down_relayed()?;
+                    self.save_device_session_relayed().await?;
+                }
             }
 
             // Log downlink frame and meta-data.

--- a/chirpstack/src/test/relay_otaa_test.rs
+++ b/chirpstack/src/test/relay_otaa_test.rs
@@ -352,6 +352,74 @@ async fn test_lorawan_10() {
             gateway_id: "0102030405060708".to_string(),
             ..Default::default()
         }),
+        assert::downlink_frame_saved(internal::DownlinkFrame {
+            dev_eui: vec![1, 1, 1, 1, 1, 1, 1, 2],
+            dev_eui_relayed: vec![1, 1, 1, 1, 1, 1, 1, 1],
+            nwk_s_enc_key: vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+            a_f_cnt_down: 5,
+            n_f_cnt_down: 5,
+            downlink_frame: Some(gw::DownlinkFrame {
+                items: vec![
+                    gw::DownlinkFrameItem {
+                        phy_payload: phy_relay_ja.to_vec().unwrap(),
+                        tx_info_legacy: None,
+                        tx_info: Some(gw::DownlinkTxInfo {
+                            frequency: 868100000,
+                            power: 16,
+                            modulation: Some(gw::Modulation {
+                                parameters: Some(gw::modulation::Parameters::Lora(
+                                    gw::LoraModulationInfo {
+                                        bandwidth: 125000,
+                                        spreading_factor: 12,
+                                        code_rate: gw::CodeRate::Cr45.into(),
+                                        polarization_inversion: true,
+                                        ..Default::default()
+                                    },
+                                )),
+                            }),
+                            timing: Some(gw::Timing {
+                                parameters: Some(gw::timing::Parameters::Delay(
+                                    gw::DelayTimingInfo {
+                                        delay: Some(Duration::from_secs(1).into()),
+                                    },
+                                )),
+                            }),
+                            ..Default::default()
+                        }),
+                    },
+                    gw::DownlinkFrameItem {
+                        phy_payload: phy_relay_ja.to_vec().unwrap(),
+                        tx_info_legacy: None,
+                        tx_info: Some(gw::DownlinkTxInfo {
+                            frequency: 869525000,
+                            power: 29,
+                            modulation: Some(gw::Modulation {
+                                parameters: Some(gw::modulation::Parameters::Lora(
+                                    gw::LoraModulationInfo {
+                                        bandwidth: 125000,
+                                        spreading_factor: 12,
+                                        code_rate: gw::CodeRate::Cr45.into(),
+                                        polarization_inversion: true,
+                                        ..Default::default()
+                                    },
+                                )),
+                            }),
+                            timing: Some(gw::Timing {
+                                parameters: Some(gw::timing::Parameters::Delay(
+                                    gw::DelayTimingInfo {
+                                        delay: Some(Duration::from_secs(2).into()),
+                                    },
+                                )),
+                            }),
+                            ..Default::default()
+                        }),
+                    },
+                ],
+                gateway_id: "0102030405060708".to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
     ];
 
     for assert in &assertions {


### PR DESCRIPTION
Fixes #1013.

#### Root cause

`save_downlink_frame_relayed()` in `downlink/join.rs` does not set `dev_eui_relayed` on the saved `internal::DownlinkFrame` (its counterpart in `downlink/data.rs` does set it). When the tx ack for a relayed JoinAccept (`ForwardDownlinkReq` on fPort 226) arrives, `_handle_relayed()` → `get_device_data_relayed()` calls `EUI64::from_slice()` on the empty value, which aborts the tx ack handling — most visibly skipping the downlink frame-logging.

This also corrects the inference in #1013: the failing downlinks are relayed JoinAccepts, not relay-configuration downlinks. Relay configuration mac-commands (`UpdateUplinkListReq` etc.) are transported on fPort 0 / FOpts and never reach `_handle_relayed()` — the only producers of fPort 226 downlinks are the two `ForwardDownlinkReq` paths (data + join-accept), and only the join-accept path forgot to store `dev_eui_relayed`. The observed error frequency matches devices (re)joining through the relay.

#### Changes

- `downlink/join.rs`: set `dev_eui_relayed` when saving the relayed JoinAccept downlink-frame (root cause).
- `downlink/tx_ack.rs`: guard the relayed-device handling on a non-empty `dev_eui_relayed`, so that a frame violating this invariant can no longer abort the remaining tx ack handling / frame-logging (matching the empty-value guards already used by the logging functions in the same file).
- `test/relay_otaa_test.rs`: assert that the saved downlink-frame of a relayed JoinAccept carries `dev_eui_relayed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
