### PR TITLE
Support for mutual TLS for redis and postgres

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,6 +706,7 @@ dependencies = [
  "chirpstack_api",
  "chrono",
  "clap",
+ "deadpool",
  "deadpool-redis",
  "diesel",
  "diesel-async",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5539,6 +5539,7 @@ dependencies = [
  "socket2",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@
     # API
     prost = "0.14"
     prost-types = "0.14"
-    tonic = { version = "0.14", default-features = false }
+    tonic = { version = "0.14", default-features = false, features = ["transport", "tls-ring"] }
     tonic-build = { version = "0.14", default-features = false }
     tonic-prost-build = { version = "0.14", default-features = false }
     tonic-prost = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@
     tokio-postgres-rustls = { version = "0.14" }
     bigdecimal = "0.4"
     redis = { version = "1.4", features = ["tls-rustls", "tokio-rustls-comp"] }
+    deadpool = { version = "0.13.0", features = ["rt_tokio_1"] }
     deadpool-redis = { version = "0.23", features = ["cluster", "serde"] }
 
     # Error

--- a/chirpstack/Cargo.toml
+++ b/chirpstack/Cargo.toml
@@ -35,6 +35,7 @@
   tokio-postgres-rustls = { workspace = true, optional = true }
   bigdecimal.workspace = true
   redis.workspace = true
+  deadpool.workspace = true
   deadpool-redis.workspace = true
 
   # Logging

--- a/chirpstack/configuration/chirpstack.toml
+++ b/chirpstack/configuration/chirpstack.toml
@@ -16,10 +16,15 @@
   #
   # SSL mode options:
   #  * disable - no SSL
-  #  * require - Always SSL (skip verification)
-  #  * verify-ca - Always SSL (verify that the certificate presented by the server was signed by a trusted CA)
-  #  * verify-full - Always SSL (verify that the certification presented by the server was signed by a trusted CA and the server host name matches the one in the certificate)
+  #  * prefer - SSL if available, fall back to no SSL. Do not use if you are serious about security.
+  #  * require - Always SSL with full verification. Behaves like verify-full in all other drivers.
+  # https://github.com/jbg/tokio-postgres-rustls/issues/11
   dsn = "postgres://chirpstack:chirpstack@localhost/chirpstack?sslmode=disable"
+
+  # for TLS
+  ca_cert = ''
+  tls_key = ''
+  tls_cert = ''
 
   # Max open connections.
   #
@@ -59,6 +64,11 @@
   # Set this to true when the provided URLs are pointing to a Redis Cluster
   # instance.
   cluster = false
+
+  # for TLS
+  ca_cert = ''
+  tls_key = ''
+  tls_cert = ''
 
 
 # Network related configuration.

--- a/chirpstack/configuration/chirpstack.toml
+++ b/chirpstack/configuration/chirpstack.toml
@@ -106,6 +106,11 @@
   # interface:port to bind the API interface to.
   bind = "0.0.0.0:8080"
 
+  # for (m)TLS. This does not provide authorization, you still have to configure and use oauth/openidconnect/internal
+  ca_cert = ''
+  tls_key = ''
+  tls_cert = ''
+
   # Secret.
   #
   # This secret is used for generating login and API tokens, make sure this

--- a/chirpstack/src/api/mod.rs
+++ b/chirpstack/src/api/mod.rs
@@ -33,6 +33,7 @@ use rust_embed::RustEmbed;
 use tokio::task;
 use tokio::try_join;
 use tonic_reflection::server::Builder as TonicReflectionBuilder;
+use tonic::transport::{Certificate, Identity, ServerTlsConfig};
 use tonic_web::GrpcWebLayer;
 use tower::Service;
 use tower::util::ServiceExt;
@@ -94,8 +95,8 @@ struct Asset;
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
 pub async fn setup() -> Result<()> {
-    let conf = config::get();
-    let bind = conf.api.bind.parse().context("Parse api.bind config")?;
+    let conf = config::get().api.clone();
+    let bind = conf.bind.parse().context("Parse api.bind config")?;
 
     info!(bind = %bind, "Setting up API interface");
 
@@ -108,7 +109,7 @@ pub async fn setup() -> Result<()> {
         .into_service()
         .map_response(|r| r.map(tonic::body::Body::new));
 
-    let grpc = TonicServer::builder()
+    let mut server = TonicServer::builder()
         .accept_http1(true)
         .layer(
             TraceLayer::new_for_grpc()
@@ -123,7 +124,31 @@ pub async fn setup() -> Result<()> {
         )
         .layer(grpc_multiplex::GrpcMultiplexLayer::new(web))
         .layer(ApiLoggerLayer {})
-        .layer(GrpcWebLayer::new())
+        .layer(GrpcWebLayer::new());
+
+    if !conf.ca_cert.is_empty() || !conf.tls_cert.is_empty() || !conf.tls_key.is_empty() {
+        info!(
+            "Configuring api with TLS certificate, ca_cert: {}, tls_cert: {}, tls_key: {}",
+            conf.ca_cert, conf.tls_cert, conf.tls_key
+        );
+
+        let mut tls_config = ServerTlsConfig::new();
+        if !conf.ca_cert.is_empty() {
+            tls_config = tls_config
+                .client_ca_root(Certificate::from_pem(std::fs::read(conf.ca_cert)?))
+                .client_auth_optional(false);
+        }
+
+        if !conf.tls_cert.is_empty() && !conf.tls_key.is_empty() {
+            tls_config = tls_config.identity(Identity::from_pem(
+                std::fs::read(conf.tls_cert)?,
+                std::fs::read(conf.tls_key)?,
+            ));
+        }
+        server = server.tls_config(tls_config)?
+    }
+
+    let grpc = server
         .add_service(
             TonicReflectionBuilder::configure()
                 .register_encoded_file_descriptor_set(chirpstack_api::api::DESCRIPTOR)
@@ -131,7 +156,7 @@ pub async fn setup() -> Result<()> {
                 .unwrap(),
         )
         .add_service(InternalServiceServer::with_interceptor(
-            internal::Internal::new(validator::RequestValidator::new(), conf.api.secret.clone()),
+            internal::Internal::new(validator::RequestValidator::new(), conf.secret.clone()),
             auth::auth_interceptor,
         ))
         .add_service(ApplicationServiceServer::with_interceptor(

--- a/chirpstack/src/config.rs
+++ b/chirpstack/src/config.rs
@@ -134,6 +134,9 @@ impl Default for Sqlite {
 pub struct Api {
     pub bind: String,
     pub secret: String,
+    pub ca_cert: String,
+    pub tls_cert: String,
+    pub tls_key: String,
 }
 
 impl Default for Api {
@@ -141,6 +144,9 @@ impl Default for Api {
         Api {
             bind: "0.0.0.0:8080".into(),
             secret: "".into(),
+            ca_cert: "".into(),
+            tls_cert: "".into(),
+            tls_key: "".into(),
         }
     }
 }

--- a/chirpstack/src/config.rs
+++ b/chirpstack/src/config.rs
@@ -59,6 +59,9 @@ pub struct Postgresql {
     pub dsn: String,
     pub max_open_connections: u32,
     pub ca_cert: String,
+    pub tls_cert: String,
+    pub tls_key: String,
+    pub application_name: String,
     pub connection_recycling_method: String,
 }
 
@@ -68,6 +71,10 @@ impl Default for Postgresql {
             dsn: "postgresql://chirpstack:chirpstack@localhost/chirpstack?sslmode=disable".into(),
             max_open_connections: 10,
             ca_cert: "".into(),
+            tls_cert: "".into(),
+            tls_key: "".into(),
+            application_name: "".into(),
+
             connection_recycling_method: "verified".into(),
         }
     }

--- a/chirpstack/src/config.rs
+++ b/chirpstack/src/config.rs
@@ -87,6 +87,9 @@ pub struct Redis {
     pub cluster: bool,
     pub key_prefix: String,
     pub max_open_connections: u32,
+    pub ca_cert: String,
+    pub tls_cert: String,
+    pub tls_key: String,
 }
 
 impl Default for Redis {
@@ -96,6 +99,9 @@ impl Default for Redis {
             cluster: false,
             key_prefix: "".into(),
             max_open_connections: 100,
+            ca_cert: "".into(),
+            tls_cert: "".into(),
+            tls_key: "".into(),
         }
     }
 }

--- a/chirpstack/src/storage/mod.rs
+++ b/chirpstack/src/storage/mod.rs
@@ -70,15 +70,39 @@ pub use postgres::{AsyncPgPoolConnection as AsyncDbPoolConnection, get_async_db_
 #[cfg(feature = "sqlite")]
 pub use sqlite::{AsyncSqlitePoolConnection as AsyncDbPoolConnection, get_async_db_conn};
 
+pub struct TlsManager {
+    client: redis::Client,
+}
+
+impl deadpool::managed::Manager for TlsManager {
+    type Type = redis::aio::MultiplexedConnection;
+    type Error = redis::RedisError;
+
+    async fn create(&self) -> Result<Self::Type, Self::Error> {
+        self.client.get_multiplexed_async_connection().await
+    }
+
+    async fn recycle(
+        &self,
+        conn: &mut Self::Type,
+        _: &deadpool::managed::Metrics,
+    ) -> deadpool::managed::RecycleResult<Self::Error> {
+        redis::cmd("PING").query_async::<()>(conn).await?;
+        Ok(())
+    }
+}
+
 #[derive(Clone)]
 pub enum AsyncRedisPool {
     Client(deadpool_redis::Pool),
     ClusterClient(deadpool_redis::cluster::Pool),
+    TlsClient(deadpool::managed::Pool<TlsManager>),
 }
 
 pub enum AsyncRedisPoolConnection {
     Client(deadpool_redis::Connection),
     ClusterClient(deadpool_redis::cluster::Connection),
+    TlsClient(deadpool::managed::Object<TlsManager>),
 }
 
 impl ConnectionLike for AsyncRedisPoolConnection {
@@ -89,6 +113,7 @@ impl ConnectionLike for AsyncRedisPoolConnection {
         match self {
             AsyncRedisPoolConnection::Client(v) => v.req_packed_command(cmd),
             AsyncRedisPoolConnection::ClusterClient(v) => v.req_packed_command(cmd),
+            AsyncRedisPoolConnection::TlsClient(v) => v.req_packed_command(cmd),
         }
     }
     fn req_packed_commands<'a>(
@@ -100,12 +125,14 @@ impl ConnectionLike for AsyncRedisPoolConnection {
         match self {
             AsyncRedisPoolConnection::Client(v) => v.req_packed_commands(cmd, offset, count),
             AsyncRedisPoolConnection::ClusterClient(v) => v.req_packed_commands(cmd, offset, count),
+            AsyncRedisPoolConnection::TlsClient(v) => v.req_packed_commands(cmd, offset, count),
         }
     }
     fn get_db(&self) -> i64 {
         match self {
             AsyncRedisPoolConnection::Client(v) => v.get_db(),
             AsyncRedisPoolConnection::ClusterClient(v) => v.get_db(),
+            AsyncRedisPoolConnection::TlsClient(v) => v.get_db(),
         }
     }
 }
@@ -130,6 +157,34 @@ pub async fn setup() -> Result<()> {
             .max_size(conf.redis.max_open_connections as usize)
             .build()?;
         set_async_redis_pool(AsyncRedisPool::ClusterClient(pool)).await;
+    } else if !conf.redis.tls_cert.is_empty() && !conf.redis.tls_key.is_empty() {
+        info!(
+            "Configuring Redis with client TLS certificate, ca_cert: {}, tls_cert: {}, tls_key: {}",
+            conf.redis.ca_cert, conf.redis.tls_cert, conf.redis.tls_key
+        );
+
+        let root_cert = if conf.redis.ca_cert.is_empty() {
+            None
+        } else {
+            Some(tokio::fs::read(&conf.redis.ca_cert).await?)
+        };
+        let client_cert = tokio::fs::read(&conf.redis.tls_cert).await?;
+        let client_key = tokio::fs::read(&conf.redis.tls_key).await?;
+
+        let tls_certs = redis::TlsCertificates {
+            client_tls: Some(redis::ClientTlsConfig {
+                client_cert,
+                client_key,
+            }),
+            root_cert,
+        };
+
+        let client = redis::Client::build_with_tls(conf.redis.servers[0].clone(), tls_certs)?;
+        let manager = TlsManager { client };
+        let pool = deadpool::managed::Pool::builder(manager)
+            .max_size(conf.redis.max_open_connections as usize)
+            .build()?;
+        set_async_redis_pool(AsyncRedisPool::TlsClient(pool)).await;
     } else {
         let pool = deadpool_redis::Config::from_url(conf.redis.servers[0].clone())
             .builder()?
@@ -166,7 +221,8 @@ pub async fn get_async_redis_conn() -> Result<AsyncRedisPoolConnection> {
         AsyncRedisPool::Client(v) => AsyncRedisPoolConnection::Client(v.get().await?),
         AsyncRedisPool::ClusterClient(v) => {
             AsyncRedisPoolConnection::ClusterClient(v.clone().get().await?)
-        }
+        },
+        AsyncRedisPool::TlsClient(v) => AsyncRedisPoolConnection::TlsClient(v.get().await?)
     };
 
     STORAGE_REDIS_CONN_GET.observe(start.elapsed().as_secs_f64());

--- a/chirpstack/src/storage/postgres.rs
+++ b/chirpstack/src/storage/postgres.rs
@@ -15,7 +15,7 @@ use futures::{FutureExt, future::BoxFuture};
 use prometheus_client::metrics::histogram::{Histogram, exponential_buckets};
 
 use crate::config;
-use crate::helpers::tls::get_root_certs;
+use crate::helpers::tls::{get_root_certs, load_cert, load_key};
 
 pub type AsyncPgPool = DeadpoolPool<AsyncPgConnection>;
 pub type AsyncPgPoolConnection = DeadpoolObject<AsyncPgConnection>;
@@ -34,7 +34,11 @@ static STORAGE_PG_CONN_GET: LazyLock<Histogram> = LazyLock::new(|| {
 pub fn setup(conf: &config::Postgresql) -> Result<()> {
     info!("Setting up PostgreSQL connection pool");
     let mut config = ManagerConfig::default();
-    config.custom_setup = Box::new(pg_establish_connection);
+
+    let conf_clone = conf.clone();
+    config.custom_setup = Box::new(move |_url| {
+        pg_establish_connection(conf_clone.clone())
+    });
 
     // Set recycling method based on configuration
     config.recycling_method = match conf.connection_recycling_method.to_lowercase().as_str() {
@@ -66,21 +70,38 @@ pub fn setup(conf: &config::Postgresql) -> Result<()> {
 
 // Source:
 // https://github.com/weiznich/diesel_async/blob/main/examples/postgres/pooled-with-rustls/src/main.rs
-fn pg_establish_connection(config: &str) -> BoxFuture<'_, ConnectionResult<AsyncPgConnection>> {
-    let fut = async {
-        let conf = config::get();
-
-        let root_certs = get_root_certs(if conf.postgresql.ca_cert.is_empty() {
+fn pg_establish_connection(conf: config::Postgresql) -> BoxFuture<'static, ConnectionResult<AsyncPgConnection>> {
+    let fut = async move {
+        let root_certs = get_root_certs(if conf.ca_cert.is_empty() {
             None
         } else {
-            Some(conf.postgresql.ca_cert.clone())
-        })
-        .map_err(|e| ConnectionError::BadConnection(e.to_string()))?;
-        let rustls_config = rustls::ClientConfig::builder()
-            .with_root_certificates(root_certs)
-            .with_no_client_auth();
+            Some(conf.ca_cert.clone())
+        }).map_err(|e| ConnectionError::BadConnection(e.to_string()))?;
+
+        let rustls_config = if !conf.tls_cert.is_empty() && !conf.tls_key.is_empty() {
+            info!(
+                "Configuring postgresql with client TLS certificate, ca_cert: {}, tls_cert: {}, tls_key: {}",
+                conf.ca_cert, conf.tls_cert, conf.tls_key
+            );
+
+            rustls::ClientConfig::builder()
+                .with_root_certificates(root_certs.clone())
+                .with_client_auth_cert(
+                    load_cert(&conf.tls_cert).await.map_err(|e| ConnectionError::BadConnection(e.to_string()))?,
+                    load_key(&conf.tls_key).await.map_err(|e| ConnectionError::BadConnection(e.to_string()))?
+            ).map_err(|e| ConnectionError::BadConnection(e.to_string()))?
+        } else {
+            rustls::ClientConfig::builder()
+                 .with_root_certificates(root_certs.clone())
+                .with_no_client_auth()
+        };
+
         let tls = tokio_postgres_rustls::MakeRustlsConnect::new(rustls_config);
-        let (client, conn) = tokio_postgres::connect(config, tls)
+        let (client, conn) = conf.dsn
+            .parse::<tokio_postgres::Config>()
+            .map_err(|e| ConnectionError::BadConnection(e.to_string()))?
+            .application_name(if conf.tls_cert.is_empty() { "chirpstack".into() } else { conf.tls_cert.clone() })
+            .connect(tls)
             .await
             .map_err(|e| ConnectionError::BadConnection(e.to_string()))?;
         tokio::spawn(async move {


### PR DESCRIPTION
Security is not optional in my organisation, so I extended the respective driver configuration code to handle full TLS verification and updated the sample configuration. My rust is far from perfect, so feedback is very welcome :)

It appears to work, but my test server has not yet seen actual traffic, as I still need to integrate MQTT. Probably requires some more testing, but I thought it'd be nice to have this work publicly available.